### PR TITLE
Remove an unneeded ResMut

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -152,7 +152,7 @@ pub trait TileMap<T: Tile, C: Chunk<T>>:
     /// Adds a `Chunk`, creates a handle and stores it at a coordinate position.
     ///
     /// This is the correct way to add a `Chunk`.
-    fn add_chunk<I: ToIndex>(&mut self, chunk: C, v: I, chunks: &mut ResMut<Assets<C>>) {
+    fn add_chunk<I: ToIndex>(&mut self, chunk: C, v: I, chunks: &mut Assets<C>) {
         let index = v.to_index(self.dimensions().x(), self.dimensions().y());
         let handle = chunks.add(chunk);
         self.send_event(MapEvent::Created {

--- a/src/map.rs
+++ b/src/map.rs
@@ -174,7 +174,7 @@ pub trait TileMap<T: Tile, C: Chunk<T>>:
         handle: H,
         chunk: C,
         v: I,
-        chunks: &mut ResMut<Assets<C>>,
+        chunks: &mut Assets<C>,
     ) -> DimensionResult<()> {
         let index = v.to_index(self.dimensions().x(), self.dimensions().y());
         self.check_index(index)?;


### PR DESCRIPTION
I believe this ResMut is unnecessary since they deref to a mutable reference and you can just pass that into the function. Taking the mutable reference directly also allows this function to be called from thread local systems where `Resources.get_mut` returns a `RefMut` rather than a `ResMut`. There may be a way to convert between those types, but just removing the wrapper entirely seems cleaner.