### PR TITLE
Add a marker component to map chunk sprites so they can be identified…

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -56,6 +56,10 @@ pub trait Chunk<T: Tile>: 'static + Dimensions3 + TypeUuid + Default + Send + Sy
     fn clean(&mut self);
 }
 
+/// A marker component used to identify map chunk entities
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ChunkSprite;
+
 /// A basic use of the `Chunk` trait that has the bare minimum methods.
 ///
 /// Serde skips the textures and texture_handle field for three reasons:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod tile;
 
 use crate::lib::*;
 pub use crate::{
-    chunk::{Chunk, WorldChunk},
+    chunk::{Chunk, WorldChunk, ChunkSprite},
     map::{TileMap, WorldMap},
     tile::Tile,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod tile;
 
 use crate::lib::*;
 pub use crate::{
-    chunk::{Chunk, WorldChunk, ChunkSprite},
+    chunk::{Chunk, ChunkSprite, WorldChunk},
     map::{TileMap, WorldMap},
     tile::Tile,
 };

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,5 +1,5 @@
 use crate::{
-    chunk::Chunk,
+    chunk::{Chunk, ChunkSprite},
     coord::{ToCoord3, ToIndex},
     dimensions::{DimensionResult, Dimensions2},
     lib::*,
@@ -615,6 +615,7 @@ pub fn map_system<T, C, M>(
                     .lock()
                     .unwrap()
                     .spawn(sprite)
+                    .with(ChunkSprite)
                     .current_entity()
                     .unwrap();
                 context.map.lock().unwrap().insert_entity(*idx, entity);


### PR DESCRIPTION
I would like to be able to identify the sprites associated with a tile map from my systems. This PR represents the least invasive change I can think of, simply adding a marker component to the entities that map_system spawns. That solves the problem for me in the case where I have a single tile map.

I would however like to have multiple tile maps in which case I need to be able to identify which map a given chunk is from. To handle that and to ease map wide operations, like parallax effects, I think it makes sense to have an entity of which all a map's chunks are children. In addition to that you need to be able to associate a given map->chunks hierarchy with the actual tile map that produced it. To handle that I propose adding an associated type to either `TileMap` or `Chunk` (or both) which represents the marker component which will be added to the parent and chunk entities when they are spawned.

I haven't included those more involved changes in this PR but if they make sense to you, I'd be happy to write them up.