### PR TITLE
allow creating chunks with odd dimensions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,7 @@ mod lib {
         bevy_app::{AppBuilder, Events, Plugin},
         bevy_asset::{AddAsset, Assets, Handle},
         bevy_core::Byteable,
-        bevy_ecs::{Bundle, Query},
-        bevy_ecs::{Commands, Entity, IntoQuerySystem, ResMut, Resources},
+        bevy_ecs::{Bundle, Commands, Entity, IntoQuerySystem, Query, ResMut, Resources},
         bevy_math::{Vec2, Vec3},
         bevy_render::{
             color::Color,
@@ -85,17 +84,13 @@ mod lib {
             pipeline::{
                 BlendDescriptor, BlendFactor, BlendOperation, ColorStateDescriptor, ColorWrite,
                 CompareFunction, CullMode, DepthStencilStateDescriptor, DynamicBinding, FrontFace,
-                PipelineDescriptor, RasterizationStateDescriptor, StencilStateDescriptor,
-                StencilStateFaceDescriptor,
+                PipelineDescriptor, RasterizationStateDescriptor, RenderPipeline, RenderPipelines,
+                StencilStateDescriptor, StencilStateFaceDescriptor,
             },
-            render_graph::{RenderGraph, RenderResourcesNode},
+            render_graph::{base::MainPass, RenderGraph, RenderResourcesNode},
             renderer::{RenderResource, RenderResources},
             shader::{Shader, ShaderStage, ShaderStages},
             texture::TextureFormat,
-        },
-        bevy_render::{
-            pipeline::{RenderPipeline, RenderPipelines},
-            render_graph::base::MainPass,
         },
         bevy_sprite::TextureAtlas,
         bevy_transform::{

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -32,27 +32,24 @@ impl From<ChunkMesh> for Mesh {
         let chunk_height = chunk_mesh.height() as i32;
         let step_size_x = 1. / chunk_width as f32;
         let step_size_y = 1. / chunk_height as f32;
+        let start_x = chunk_width as f32 * -0.5;
+        let start_y = chunk_height as f32 * -0.5;
         let mut vertices = Vec::with_capacity((chunk_width * chunk_height) as usize * 4);
-        for y in (-chunk_height / 2)..(chunk_height / 2) {
-            for x in (-chunk_width / 2)..(chunk_width / 2) {
-                vertices.push([x as f32 * step_size_x, y as f32 * step_size_y, 0.0]);
+        for y in 0..chunk_height {
+            for x in 0..chunk_width {
+                let y = start_y + y as f32;
+                let x = start_x + x as f32;
+                vertices.push([x * step_size_x, y * step_size_y, 0.0]);
+                vertices.push([x * step_size_x, y * step_size_y + step_size_y, 0.0]);
                 vertices.push([
-                    x as f32 * step_size_x,
-                    y as f32 * step_size_y + step_size_y,
+                    x * step_size_x + step_size_x,
+                    y * step_size_y + step_size_y,
                     0.0,
                 ]);
-                vertices.push([
-                    x as f32 * step_size_x + step_size_x,
-                    y as f32 * step_size_y + step_size_y,
-                    0.0,
-                ]);
-                vertices.push([
-                    x as f32 * step_size_x + step_size_x,
-                    y as f32 * step_size_y,
-                    0.0,
-                ]);
+                vertices.push([x * step_size_x + step_size_x, y * step_size_y, 0.0]);
             }
         }
+
         let indices = Indices::U32(
             (0..(chunk_width * chunk_height) as u32)
                 .flat_map(|i| {


### PR DESCRIPTION
small fix to mesh creation, chunks with odd dimensions were dropping a column and/or row because of the integer truncation. i looked for some more rusty way of iterating floats but they all required a bunch of code or more dependencies so I did this instead

verified the example still renders and all tests still pass, not sure what else might be required here