### PR TITLE
Change Tile by expanding it with more usable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,86 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+* `Tilemap::clear_tile` was added to easily clear a single tile.
+* `Tilemap::clear_tiles` likewise will clear an array of tiles.
+* `Point2` now implements `From<&Point2>`.
+* `Point3` now implements `From<&Point3>`.
+* `tilemap::Tilemap::set_tiles` now implements 
+`IntoIterator<Item = ((i32, i32, i32), Tile)>` which had broken the previous 
+compatibility.
+* `tile::Tile` had the `non_exhaustive` derive added it now that the fields are
+all public.
+* `tile::Tile` added methods `with_tint` and `with_tint_and_z_order`.
+
+### Changed
+
+* `Tilemap::set_tiles` was changed to take in a `IntoIterator<Item = Tile<P, C>`,
+where `C` is `Into<Color>` and P is `Into<Point2>`, from 
+`IntoIterator<Item = (i32, i32, i32), Tile>`.
+* `tile::Tile` was changed to include `z_order`, `sprite_index`, and `point`.
+Field `color` is now `tint`. All fields were made public.
+* `tile::Tile` methods `default`, `new` updated.
+
+**Before**
+```rust
+let z_order = 0;
+let point = (1, 1, z_order)
+let tile = Tile::new(0);
+let tiles = vec![(point, tile)];
+ 
+// defined elsewhere
+tilemap.set_tiles(tiles).unwrap();
+```
+
+**After**
+```rust
+let point = (1, 1);
+let z_order = 0;
+let tiles = vec![Tile::new(point, z_order)];
+
+// defined elsewhere
+tilemap.set_tiles(tiles).unwrap();
+```
+
+* `Tilemap::set_tile` was changed to take in `Tile<P, C>`, where `P` is 
+`Into<Point2>` and `C` is `Into<Color>`. This replaces the previous argument
+`P` and `T` where `T` was `Into<Tile>`.
+
+**Before**
+```rust
+let point = (9, 3, 0);
+let sprite_index = 3;
+let tile = Tile::new(sprite_index);
+
+// defined elsewhere
+tilemap.set(point, tile).unwrap();
+```
+
+**After**
+```rust
+let point = (9, 3);
+let sprite_index = 3;
+let tile = Tile::new(point, sprite_index);
+
+tilemap.set_tile(tile).unwrap();
+```
+
+### Removed
+
+* `tile::Tiles` was removed as it is no longer needed as all data as been set
+into `Tile` to make everything easier.
+* `tile::Tiles` was removed from `prelude`.
+* `tile::Tile` methods `index` and `color` were removed as the fields are now
+public.
+* `tile::Tile` all `<Into<Tile>>` implements were removed.
+
 ## [0.2.1] - 2020-11-21
 
 ### Added
 
 * Minimum supported rust version (MSRV) were noted to be 1.43.0 in documents.
-
 
 ### Fixes
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,10 @@
 //! let mut tilemap = Tilemap::new(texture_atlas_handle);
 //!
 //! // Coordinate point with Z order.
-//! let point = (16, 16, 0);
-//! let tile_index = 0;
-//! tilemap.set_tile(point, tile_index);
+//! let point = (16, 16);
+//! let sprite_index = 0;
+//! let tile = Tile::new(point, sprite_index);
+//! tilemap.set_tile(tile);
 //!
 //! tilemap.spawn_chunk_containing_point(point);
 //! ```
@@ -104,10 +105,10 @@
 //! let mut tilemap = Tilemap::new(texture_atlas_handle);
 //!
 //! // Prefer this
-//! let mut tiles = Tiles::default();
+//! let mut tiles = Vec::new();
 //! for y in 0..31 {
 //!     for x in 0..31 {
-//!         tiles.insert((x, y, 0), 0.into());
+//!         tiles.push(Tile::new((x, y, 0), 0));
 //!     }
 //! }
 //!
@@ -116,7 +117,7 @@
 //! // Over this...
 //! for y in 0..31 {
 //!     for x in 0..31 {
-//!         tilemap.set_tile((x, y, 0), 0);
+//!         tilemap.set_tile(Tile::new((x, y, 0), 0));
 //!     }
 //! }
 //! ```

--- a/src/point.rs
+++ b/src/point.rs
@@ -47,6 +47,12 @@ impl Display for Point2 {
     }
 }
 
+impl From<&Point2> for Point2 {
+    fn from(point: &Point2) -> Point2 {
+        *point
+    }
+}
+
 impl From<Point2> for Vec2 {
     fn from(point: Point2) -> Vec2 {
         Vec2::new(point.x as f32, point.y as f32)
@@ -324,9 +330,21 @@ impl Display for Point3 {
     }
 }
 
+impl From<Point3> for Point2 {
+    fn from(point: Point3) -> Point2 {
+        Point2::new(point.x, point.y)
+    }
+}
+
 impl From<&Point3> for Point2 {
     fn from(point: &Point3) -> Point2 {
         Point2::new(point.x, point.y)
+    }
+}
+
+impl From<&Point3> for Point3 {
+    fn from(point: &Point3) -> Point3 {
+        *point
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -33,15 +33,10 @@
 //! [`bevy_tilemap`]: crate
 
 /// The 0.2 prelude version of Bevy Tilemap.
-pub mod v0_2 {
+pub mod v0 {
     pub use crate::{
-        chunk::LayerKind,
-        entity::TilemapComponents,
-        tile::{Tile, Tiles},
-        tilemap::Tilemap,
-        ChunkTilesPlugin,
+        chunk::LayerKind, entity::TilemapComponents, tile::Tile, tilemap::Tilemap, ChunkTilesPlugin,
     };
 }
 
-#[cfg(not(v0_1))]
-pub use v0_2::*;
+pub use v0::*;

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -81,9 +81,9 @@ impl<P: Into<Point2>, C: Into<Color>> Tile<P, C> {
     ///
     /// let point = (15, 15);
     /// let sprite_index = 3;
-    /// let color = Color::BLUE;
+    /// let tint = Color::BLUE;
     ///
-    /// let tile = Tile::with_tint(0, sprite_index, color);
+    /// let tile = Tile::with_tint(point, sprite_index, tint);
     /// ```
     ///
     /// [`Color`]: Bevy::render::color::Color
@@ -103,12 +103,12 @@ impl<P: Into<Point2>, C: Into<Color>> Tile<P, C> {
     /// # Examples
     /// ```
     /// use bevy_tilemap::prelude::*;
-    /// use bevy_prelude::*;
+    /// use bevy::prelude::*;
     ///
     /// let point = (15, 15);
     /// let z_order = 0;
     /// let sprite_index = 2;
-    /// let tint = Color::YELLOW;
+    /// let tint = Color::RED;
     ///
     /// let tile = Tile::with_z_order_and_tint(point, z_order, sprite_index, tint);
     /// ```

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,20 +1,142 @@
-use crate::{lib::*, point::Point3};
+use crate::{lib::*, point::Point2};
 
-/// A hash map type to use for setting tiles.
-pub type Tiles = HashMap<(i32, i32, i32), Tile>;
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub(crate) struct RawTile {
+    pub index: usize,
+    pub color: Color,
+}
 
-pub(crate) type TilePoints = HashMap<Point3, Tile>;
+/// A tile with an index value and color.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, PartialEq, Debug)]
+#[non_exhaustive]
+pub struct Tile<P: Into<Point2>, C: Into<Color>> {
+    /// A point where the tile will exist.
+    pub point: P,
+    /// The Z order layer of the tile. Higher will place the tile above others.
+    pub z_order: usize,
+    /// The sprites index in the texture atlas.
+    pub sprite_index: usize,
+    /// The desired tint and alpha of the tile. White means no change.
+    pub tint: C,
+}
+
+impl Default for Tile<(i32, i32), Color> {
+    fn default() -> Tile<(i32, i32), Color> {
+        Tile {
+            point: (0, 0),
+            z_order: 0,
+            sprite_index: 0,
+            tint: Color::WHITE,
+        }
+    }
+}
+
+impl<P: Into<Point2>> Tile<P, Color> {
+    /// Creates a new tile with a provided point and tile index.
+    ///
+    /// By default, this makes a tile with no tint to the color at all. If tile
+    /// tinting is needed, use [`with_color`] instead.
+    ///
+    /// # Examples
+    /// ```
+    /// use bevy_tilemap::prelude::*;
+    ///
+    /// // Creates a tile with an index of 0 at point 3x,3y
+    /// let tile = Tile::new((3, 3), 0);
+    /// ```
+    ///
+    /// [`Tile`]: Tile
+    /// [`with_color`]: Tile::with_color
+    pub fn new(point: P, sprite_index: usize) -> Tile<P, Color> {
+        Tile {
+            point,
+            z_order: 0,
+            sprite_index,
+            tint: Color::WHITE,
+        }
+    }
+
+    /// Creates a new tile with a given Z order and sprite index at a point.
+    pub fn with_z_order(point: P, sprite_index: usize, z_order: usize) -> Tile<P, Color> {
+        Tile {
+            point,
+            z_order,
+            sprite_index,
+            tint: Color::WHITE,
+        }
+    }
+}
+
+impl<P: Into<Point2>, C: Into<Color>> Tile<P, C> {
+    /// Creates a new tile with a color and a given sprite index.
+    ///
+    /// The color argument implements `Into<[`Color`]>`.
+    ///
+    /// # Examples
+    /// ```
+    /// use bevy_tilemap::prelude::*;
+    /// use bevy::prelude::*;
+    ///
+    /// let point = (15, 15);
+    /// let sprite_index = 3;
+    /// let color = Color::BLUE;
+    ///
+    /// let tile = Tile::with_tint(0, sprite_index, color);
+    /// ```
+    ///
+    /// [`Color`]: Bevy::render::color::Color
+    pub fn with_tint(point: P, sprite_index: usize, tint: C) -> Tile<P, C> {
+        Tile {
+            point,
+            z_order: 0,
+            sprite_index,
+            tint,
+        }
+    }
+
+    /// Crates a new tile with a given color, index and color at a point.
+    ///
+    /// The color argument implements `Into<[`Color`]>`.
+    ///
+    /// # Examples
+    /// ```
+    /// use bevy_tilemap::prelude::*;
+    /// use bevy_prelude::*;
+    ///
+    /// let point = (15, 15);
+    /// let z_order = 0;
+    /// let sprite_index = 2;
+    /// let tint = Color::YELLOW;
+    ///
+    /// let tile = Tile::with_z_order_and_tint(point, z_order, sprite_index, tint);
+    /// ```
+    pub fn with_z_order_and_tint(
+        point: P,
+        sprite_index: usize,
+        z_order: usize,
+        tint: C,
+    ) -> Tile<P, C> {
+        Tile {
+            point,
+            z_order,
+            sprite_index,
+            tint,
+        }
+    }
+}
 
 // TODO: Fix both these renderer parts below to only include the current depth.
 /// A utility function that takes an array of `Tile`s and splits the indexes and
 /// colors and returns them as separate vectors for use in the renderer.
-pub(crate) fn dense_tiles_to_attributes(tiles: &[Tile]) -> (Vec<f32>, Vec<[f32; 4]>) {
+pub(crate) fn dense_tiles_to_attributes(tiles: &[RawTile]) -> (Vec<f32>, Vec<[f32; 4]>) {
     let capacity = tiles.len() * 4;
     let mut tile_indexes: Vec<f32> = Vec::with_capacity(capacity);
     let mut tile_colors: Vec<[f32; 4]> = Vec::with_capacity(capacity);
     for tile in tiles.iter() {
-        tile_indexes.extend([tile.index() as f32; 4].iter());
-        tile_colors.extend([tile.color().into(); 4].iter());
+        tile_indexes.extend([tile.index as f32; 4].iter());
+        tile_colors.extend([tile.color.into(); 4].iter());
     }
     (tile_indexes, tile_colors)
 }
@@ -23,7 +145,7 @@ pub(crate) fn dense_tiles_to_attributes(tiles: &[Tile]) -> (Vec<f32>, Vec<[f32; 
 /// and colors and returns them as separate vectors for use in the renderer.
 pub(crate) fn sparse_tiles_to_attributes(
     area: usize,
-    tiles: &HashMap<usize, Tile>,
+    tiles: &HashMap<usize, RawTile>,
 ) -> (Vec<f32>, Vec<[f32; 4]>) {
     let mut tile_indexes = vec![0.; area * 4];
     // If tiles are set with an alpha of 0, they are discarded.
@@ -36,116 +158,3 @@ pub(crate) fn sparse_tiles_to_attributes(
     }
     (tile_indexes, tile_colors)
 }
-
-/// A tile with an index value and color.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Tile {
-    index: usize,
-    color: Color,
-}
-
-impl Default for Tile {
-    fn default() -> Tile {
-        Tile {
-            index: 0,
-            color: Color::WHITE,
-        }
-    }
-}
-
-impl Tile {
-    /// Creates a new a with a given index.
-    ///
-    /// By default, this makes a tile with no tint to the color at all. If tile
-    /// tinting is needed, use [`with_color`] instead.
-    ///
-    /// # Examples
-    /// ```
-    /// use bevy_tilemap::prelude::*;
-    ///
-    /// // Creates a tile with an index of 0
-    /// let tile = Tile::new(0);
-    /// ```
-    ///
-    /// [`Tile`]: Tile
-    /// [`with_color`]: Tile::with_color
-    pub fn new(index: usize) -> Tile {
-        Tile {
-            index,
-            ..Default::default()
-        }
-    }
-
-    /// Creates a new tile with a color and a given index.
-    ///
-    /// A [`Color`] is handy if you want full tinting done on a tile.
-    ///
-    /// # Examples
-    /// ```
-    /// use bevy_tilemap::prelude::*;
-    /// use bevy::prelude::*;
-    ///
-    /// let tile = Tile::with_color(0, Color::BLUE);
-    /// ```
-    ///
-    /// [`Color`]: Bevy::render::color::Color
-    pub fn with_color(index: usize, color: Color) -> Tile {
-        Tile { index, color }
-    }
-
-    /// Returns the sprite index value.
-    ///
-    /// # Examples
-    /// ```
-    /// use bevy_tilemap::prelude::*;
-    ///
-    /// let index = 0;
-    /// let tile = Tile::new(0);
-    ///
-    /// assert_eq!(index, tile.index());
-    /// ```
-    pub fn index(&self) -> usize {
-        self.index
-    }
-
-    /// Returns the tint color of the tile.
-    ///
-    /// Most cases this is white which simply means that no tint has been
-    /// applied.
-    ///
-    /// # Examples
-    /// ```
-    /// use bevy_tilemap::prelude::*;
-    /// use bevy::prelude::*;
-    ///
-    /// let color = Color::GREEN;
-    /// let tile = Tile::with_color(0, color);
-    ///
-    /// assert_eq!(color, tile.color());
-    /// ```
-    pub fn color(&self) -> Color {
-        self.color
-    }
-}
-
-macro_rules! into_tile_impl {
-    ($i: ty) => {
-        impl Into<Tile> for $i {
-            fn into(self) -> Tile {
-                Tile::new(self as usize)
-            }
-        }
-    };
-}
-
-into_tile_impl!(usize);
-into_tile_impl!(u64);
-into_tile_impl!(u32);
-into_tile_impl!(u16);
-into_tile_impl!(u8);
-into_tile_impl!(isize);
-into_tile_impl!(i64);
-into_tile_impl!(i32);
-into_tile_impl!(i16);
-into_tile_impl!(i8);

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -1096,7 +1096,7 @@ impl Tilemap {
     ///
     /// # Examples
     /// ```
-    /// # use bevy_tilemap::tilemap::Tilemap;
+    /// # use bevy_tilemap::prelude::*;
     /// # use bevy::asset::HandleId;
     /// # use bevy::prelude::*;
     /// #
@@ -1116,7 +1116,13 @@ impl Tilemap {
     ///
     /// // Then later on... Do note that if this done in the same frame, the
     /// // tiles will not even exist at all.
-    /// tilemap.remove_tiles(tiles);
+    /// let to_remove = vec![
+    ///     ((1, 1), 0),
+    ///     ((2, 2), 0),
+    ///     ((3, 3), 0),
+    /// ];
+    ///
+    /// tilemap.clear_tiles(to_remove);
     /// ```
     pub fn clear_tiles<P, I>(&mut self, points: I) -> TilemapResult<()>
     where

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -1051,8 +1051,10 @@ impl Tilemap {
 
     /// Sets a single tile at a coordinate position, creating a chunk if necessary.
     ///
-    /// For convenience, this does not require to use a TileSetter which is beneficial for multiple
-    /// tiles. If that is preferred, do use [`set_tiles`] instead.
+    /// If you are setting more than one tile at a time, it is highly
+    /// recommended not to run this method! If that is preferred, do use
+    /// [`set_tiles`] instead. Every single tile that is created creates a new
+    /// event. With bulk tiles, it creates 1 event for all.
     ///
     /// If the chunk does not yet exist, it will create a new one automatically.
     ///
@@ -1090,9 +1092,32 @@ impl Tilemap {
         self.set_tiles(tiles)
     }
 
-    // pub fn set_tile_with_zorder
-
     /// Clears the tiles at the specified points from the tilemap.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_tilemap::tilemap::Tilemap;
+    /// # use bevy::asset::HandleId;
+    /// # use bevy::prelude::*;
+    /// #
+    /// # // In production use a strong handle from an actual source.
+    /// # let texture_atlas_handle = Handle::weak(HandleId::random::<TextureAtlas>());
+    /// #
+    /// # let mut tilemap = Tilemap::new(texture_atlas_handle);
+    /// #
+    /// let mut tiles = vec![
+    ///     Tile::new((1, 1), 0),
+    ///     Tile::new((2, 2), 0),
+    ///     Tile::new((3, 3), 0)
+    /// ];
+    ///
+    /// // Set multiple tiles and unwrap the result
+    /// tilemap.set_tiles(tiles.clone()).unwrap();
+    ///
+    /// // Then later on... Do note that if this done in the same frame, the
+    /// // tiles will not even exist at all.
+    /// tilemap.remove_tiles(tiles);
+    /// ```
     pub fn clear_tiles<P, I>(&mut self, points: I) -> TilemapResult<()>
     where
         P: Into<Point2>,
@@ -1112,6 +1137,29 @@ impl Tilemap {
     }
 
     /// Clear a single tile at the specified point from the tilemap.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_tilemap::tilemap::Tilemap;
+    /// # use bevy::asset::HandleId;
+    /// # use bevy::prelude::*;
+    /// #
+    /// # // In production use a strong handle from an actual source.
+    /// # let texture_atlas_handle = Handle::weak(HandleId::random::<TextureAtlas>());
+    /// #
+    /// # let mut tilemap = Tilemap::new(texture_atlas_handle);
+    /// #
+    /// use bevy_tilemap::tile::Tile;
+    /// let point = (9, 3);
+    /// let sprite_index = 3;
+    /// let tile = Tile::new(point, sprite_index);
+    ///
+    /// // Set a single tile and unwrap the result
+    /// tilemap.set_tile(tile).unwrap();
+    ///
+    /// // Later on...
+    /// tilemap.clear_tile(point, 0);
+    /// ```
     pub fn clear_tile<P>(&mut self, point: P, z_order: usize) -> TilemapResult<()>
     where
         P: Into<Point2>,

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -812,7 +812,7 @@ impl Tilemap {
     ///
     /// tilemap.set_tile(tile);
     ///
-    /// tilemap.spawn_chunk_containing_point(tile_point);
+    /// tilemap.spawn_chunk_containing_point(point);
     /// ```
     pub fn spawn_chunk_containing_point<P: Into<Point2>>(&mut self, point: P) -> TilemapResult<()> {
         let point = self.tile_to_chunk_point(point);
@@ -984,7 +984,7 @@ impl Tilemap {
     /// #
     /// # let mut tilemap = Tilemap::new(texture_atlas_handle);
     /// #
-    /// use bevy_tilemap::tile::{Tile, Tiles};
+    /// use bevy_tilemap::tile::Tile;
     ///
     /// let mut tiles = vec![
     ///     Tile::new((1, 1), 0),

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -4,8 +4,8 @@ use crate::{
     entity::ChunkComponents,
     lib::*,
     mesh::ChunkMesh,
-    point::{Point2, Point3},
-    tile::{Tile, TilePoints, Tiles},
+    point::Point2,
+    tile::{RawTile, Tile},
 };
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -82,29 +82,29 @@ pub(crate) enum TilemapEvent {
     },
     /// An event when a layer is created for all chunks.
     AddedLayer {
-        /// The *Z* layer to add.
-        z_layer: usize,
+        /// The *Z* order to add.
+        z_order: usize,
         /// The `LayerKind` of the layer.
         kind: LayerKind,
     },
     /// An event when a layer is moved.
     MovedLayer {
-        /// From which *Z* layer.
-        from_z_layer: usize,
-        /// To which *Z* layer.
+        /// From which *Z* order.
+        from_z_order: usize,
+        /// To which *Z* order.
         to_z_layer: usize,
     },
     /// An event when a layer is removed for all chunks.
     RemovedLayer {
-        /// The *Z* layer to remove.
-        z_layer: usize,
+        /// The *Z* order to remove.
+        z_order: usize,
     },
     /// An event when a chunk had been modified by changing tiles.
     ModifiedChunk {
         /// The map index where the chunk needs to be stored.
         handle: Handle<Chunk>,
-        /// The `TileSetter` that is used to set all the tiles.
-        tiles: TilePoints,
+        /// The tiles that need to be set.
+        tiles: Vec<Tile<Point2, Color>>,
     },
     /// An event when a chunk is spawned.
     SpawnedChunk { handle: Handle<Chunk> },
@@ -607,18 +607,18 @@ impl Tilemap {
     /// ```
     ///
     /// [`LayerKind`]: crate::chunk::LayerKind
-    pub fn add_layer_with_kind(&mut self, kind: LayerKind, z_layer: usize) -> TilemapResult<()> {
-        if let Some(some_kind) = self.layers[z_layer] {
+    pub fn add_layer_with_kind(&mut self, kind: LayerKind, z_order: usize) -> TilemapResult<()> {
+        if let Some(some_kind) = self.layers[z_order] {
             return if some_kind == kind {
                 Ok(())
             } else {
-                Err(ErrorKind::LayerExists(z_layer).into())
+                Err(ErrorKind::LayerExists(z_order).into())
             };
         }
 
-        self.layers[z_layer] = Some(kind);
+        self.layers[z_order] = Some(kind);
 
-        self.events.send(TilemapEvent::AddedLayer { z_layer, kind });
+        self.events.send(TilemapEvent::AddedLayer { z_order, kind });
         Ok(())
     }
 
@@ -699,7 +699,7 @@ impl Tilemap {
         self.layers[from_z] = None;
 
         self.events.send(TilemapEvent::MovedLayer {
-            from_z_layer: from_z,
+            from_z_order: from_z,
             to_z_layer: to_z,
         });
 
@@ -742,7 +742,7 @@ impl Tilemap {
 
         self.layers[z] = None;
 
-        self.events.send(TilemapEvent::RemovedLayer { z_layer: z })
+        self.events.send(TilemapEvent::RemovedLayer { z_order: z })
     }
 
     /// Spawns a chunk at a given index or coordinate.
@@ -797,7 +797,7 @@ impl Tilemap {
     ///
     /// # Examples
     /// ```
-    /// # use bevy_tilemap::tilemap::Tilemap;
+    /// # use bevy_tilemap::prelude::*;
     /// # use bevy::asset::HandleId;
     /// # use bevy::prelude::*;
     /// #
@@ -806,9 +806,11 @@ impl Tilemap {
     /// #
     /// # let mut tilemap = Tilemap::new(texture_atlas_handle);
     /// #
-    /// let tile_point = (16, 16, 0);
-    /// let tile_index = 0;
-    /// tilemap.set_tile(tile_point, tile_index);
+    /// let point = (16, 16, 0);
+    /// let index = 0;
+    /// let tile = Tile::new(point, index);
+    ///
+    /// tilemap.set_tile(tile);
     ///
     /// tilemap.spawn_chunk_containing_point(tile_point);
     /// ```
@@ -984,44 +986,50 @@ impl Tilemap {
     /// #
     /// use bevy_tilemap::tile::{Tile, Tiles};
     ///
-    /// let mut tiles = Tiles::default();
-    /// tiles.insert((1, 1, 0), Tile::new(1));
-    /// tiles.insert((2, 2, 0), Tile::new(2));
-    /// tiles.insert((3, 3, 0), Tile::new(3));
-    ///
-    /// assert_eq!(tiles.len(), 3);
+    /// let mut tiles = vec![
+    ///     Tile::new((1, 1), 0),
+    ///     Tile::new((2, 2), 0),
+    ///     Tile::new((3, 3), 0)
+    /// ];
     ///
     /// // Set multiple tiles and unwrap the result
     /// tilemap.set_tiles(tiles).unwrap();
     /// ```
     ///
     /// [`set_tile`]: Tilemap::set_tile
-    pub fn set_tiles<T>(&mut self, tiles: T) -> TilemapResult<()>
+    pub fn set_tiles<P, C, I>(&mut self, tiles: I) -> TilemapResult<()>
     where
-        T: IntoIterator<Item = ((i32, i32, i32), Tile)>,
+        P: Into<Point2>,
+        C: Into<Color>,
+        I: IntoIterator<Item = Tile<P, C>>,
     {
         let width = self.chunk_dimensions.width() as i32;
         let height = self.chunk_dimensions.height() as i32;
 
-        let mut chunk_map: HashMap<Point2, TilePoints> = HashMap::default();
-        for (points, tile) in tiles.into_iter() {
-            let global_tile_point: Point3 = points.into();
-            let chunk_point: Point2 = self.tile_to_chunk_point(&global_tile_point).into();
+        let mut chunk_map: HashMap<Point2, Vec<Tile<Point2, Color>>> = HashMap::default();
+        for tile in tiles.into_iter() {
+            let global_tile_point: Point2 = tile.point.into();
+            let chunk_point: Point2 = self.tile_to_chunk_point(global_tile_point).into();
 
-            if self.layers[global_tile_point.z as usize].is_none() {
-                self.add_layer(global_tile_point.z as usize)?;
+            if self.layers[tile.z_order as usize].is_none() {
+                self.add_layer(tile.z_order as usize)?;
             }
 
-            let tile_point = Point3::new(
+            let tile_point = Point2::new(
                 global_tile_point.x - (width * chunk_point.x) + (width / 2),
                 global_tile_point.y - (height * chunk_point.y) + (width / 2),
-                global_tile_point.z,
             );
+
+            let chunk_tile: Tile<Point2, Color> = Tile {
+                point: tile_point,
+                z_order: tile.z_order,
+                sprite_index: tile.sprite_index,
+                tint: tile.tint.into(),
+            };
             if let Some(tiles) = chunk_map.get_mut(&chunk_point) {
-                tiles.insert(tile_point, tile);
+                tiles.push(chunk_tile);
             } else {
-                let mut tiles = TilePoints::default();
-                tiles.insert(tile_point, tile);
+                let tiles = vec![chunk_tile];
                 chunk_map.insert(chunk_point, tiles);
             }
         }
@@ -1064,22 +1072,52 @@ impl Tilemap {
     /// # let mut tilemap = Tilemap::new(texture_atlas_handle);
     /// #
     /// use bevy_tilemap::tile::Tile;
+    /// let point = (9, 3);
+    /// let sprite_index = 3;
+    /// let tile = Tile::new(point, sprite_index);
     ///
     /// // Set a single tile and unwrap the result
-    /// tilemap.set_tile((15, 15, 0), Tile::new(1)).unwrap();
+    /// tilemap.set_tile(tile).unwrap();
     /// ```
     ///
     /// [`set_tiles`]: Tilemap::set_tiles
-    pub fn set_tile<P, T>(&mut self, point: P, tile: T) -> TilemapResult<()>
+    pub fn set_tile<P, C>(&mut self, tile: Tile<P, C>) -> TilemapResult<()>
     where
-        P: Into<Point3>,
-        T: Into<Tile>,
+        P: Into<Point2>,
+        C: Into<Color>,
     {
-        let tile: Tile = tile.into();
-        let mut tiles = Tiles::default();
-        let point: Point3 = point.into();
-        tiles.insert((point.x, point.y, point.z), tile);
+        let tiles = vec![tile];
         self.set_tiles(tiles)
+    }
+
+    // pub fn set_tile_with_zorder
+
+    /// Clears the tiles at the specified points from the tilemap.
+    pub fn clear_tiles<P, I>(&mut self, points: I) -> TilemapResult<()>
+    where
+        P: Into<Point2>,
+        I: IntoIterator<Item = (P, usize)>,
+    {
+        let mut tiles = Vec::new();
+        for (point, z_order) in points {
+            tiles.push(Tile::with_z_order_and_tint(
+                point,
+                z_order,
+                0,
+                Color::rgba(0.0, 0.0, 0.0, 0.0),
+            ));
+        }
+        self.set_tiles(tiles)?;
+        Ok(())
+    }
+
+    /// Clear a single tile at the specified point from the tilemap.
+    pub fn clear_tile<P>(&mut self, point: P, z_order: usize) -> TilemapResult<()>
+    where
+        P: Into<Point2>,
+    {
+        let points = vec![(point, z_order)];
+        self.clear_tiles(points)
     }
 
     /// Returns the center tile, if the tilemap has dimensions.
@@ -1310,18 +1348,18 @@ pub fn map_system(
                     new_chunks.push((*point, handle.clone_weak()));
                 }
                 AddedLayer {
-                    z_layer: ref z,
+                    z_order: ref z,
                     ref kind,
                 } => {
                     added_layers.push((*z, *kind));
                 }
                 MovedLayer {
-                    from_z_layer: ref from_z,
+                    from_z_order: ref from_z,
                     to_z_layer: ref to_z,
                 } => {
                     moved_layers.push((*from_z, *to_z));
                 }
-                RemovedLayer { z_layer: ref z } => {
+                RemovedLayer { z_order: ref z } => {
                     removed_layers.push(*z);
                 }
                 ModifiedChunk {
@@ -1371,9 +1409,13 @@ pub fn map_system(
 
         for (handle, setter) in modified_chunks.into_iter() {
             let chunk = chunks.get_mut(&handle).expect("`Chunk` is missing.");
-            for (point, tile) in setter.into_iter() {
-                let index = map.chunk_dimensions.encode_point_unchecked(point.xy());
-                chunk.set_tile(point.z as usize, index, tile);
+            for tile in setter.into_iter() {
+                let index = map.chunk_dimensions.encode_point_unchecked(tile.point);
+                let raw_tile = RawTile {
+                    index: tile.sprite_index,
+                    color: tile.tint,
+                };
+                chunk.set_raw_tile(tile.z_order, index, raw_tile);
             }
         }
 


### PR DESCRIPTION
While working on the interactive example I have come up with a better solution for tile as I begun thinking how awkward it was to use `(i32, i32, i32)` as the `z_order` shouldn't be confused as existing in a 3D space. The `Point3` will be reserved for future use with the future layered Tilemap update.