### PR TITLE
Remove ceil from tilemap.vert

### DIFF
--- a/src/render/tilemap.vert
+++ b/src/render/tilemap.vert
@@ -51,5 +51,5 @@ void main() {
     );
     v_Uv = (atlas_positions[gl_VertexIndex % 4] + vec2(0.01, 0.01)) / AtlasSize;
     v_Color = Vertex_Tile_Color;
-    gl_Position = ViewProj * ChunkTransform * vec4(ceil(vertex_position), 1.0);
+    gl_Position = ViewProj * ChunkTransform * vec4(vertex_position, 1.0);
 }


### PR DESCRIPTION
If the tiles are odd value (i.e 31x31) and exceeding a certain size (23x23 in tests), the tiles won't snap to the coordinate correctly. Removing `ceil` at the end had resolved this.

Thanks @jamadazi for finding the problem and solution for this.