### PR TITLE
Removed all `Tile` generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 to ensure that the tiles are divisible into each other had been added.
 * Optional dimension 2D and 3D API.
 * `TilemapDefaultPlugins` was added.
+* `SpriteSheet` was added which is very much like `TextureAtlas` but it splits
+everything into tiles.
+* `point` and `dimension` modules were moved to `bevy_tilemap_types` crate but 
+still accessible as normal and optional.
+* `bevy_tilemap_spritesheet` sub-crate was added.
 
 ### Changed
 
@@ -20,6 +25,8 @@ to ensure that the tiles are divisible into each other had been added.
 * `ChunkTilesPlugin` is now `Tilemap2DPlugin`.
 * `TilemapBuilder::build()` is now `TilemapBuilder::finish()`
 * Point module was now made optional.
+* Changed the `random_dungeon` example to be more like an actual implementation.
+* `Tile` had all generics removed from it.
 
 ## [0.2.2] - 2020-11-23
 

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -45,21 +45,21 @@ pub(crate) struct RawTile {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[non_exhaustive]
-pub struct Tile<P: Into<Point2>, C: Into<Color>> {
+pub struct Tile {
     /// A point where the tile will exist.
-    pub point: P,
+    pub point: Point2,
     /// The Z order layer of the tile. Higher will place the tile above others.
     pub z_order: usize,
     /// The sprites index in the texture atlas.
     pub sprite_index: usize,
     /// The desired tint and alpha of the tile. White means no change.
-    pub tint: C,
+    pub tint: Color,
 }
 
-impl Default for Tile<(i32, i32), Color> {
-    fn default() -> Tile<(i32, i32), Color> {
+impl Default for Tile {
+    fn default() -> Tile {
         Tile {
-            point: (0, 0),
+            point: Point2::new(0, 0),
             z_order: 0,
             sprite_index: 0,
             tint: Color::WHITE,
@@ -67,7 +67,7 @@ impl Default for Tile<(i32, i32), Color> {
     }
 }
 
-impl<P: Into<Point2>> Tile<P, Color> {
+impl Tile {
     /// Creates a new tile with a provided point and tile index.
     ///
     /// By default, this makes a tile with no tint to the color at all. If tile
@@ -83,9 +83,9 @@ impl<P: Into<Point2>> Tile<P, Color> {
     ///
     /// [`Tile`]: Tile
     /// [`with_tint`]: Tile::with_tint
-    pub fn new(point: P, sprite_index: usize) -> Tile<P, Color> {
+    pub fn new<P: Into<Point2>>(point: P, sprite_index: usize) -> Tile {
         Tile {
-            point,
+            point: point.into(),
             z_order: 0,
             sprite_index,
             tint: Color::WHITE,
@@ -93,17 +93,15 @@ impl<P: Into<Point2>> Tile<P, Color> {
     }
 
     /// Creates a new tile with a given Z order and sprite index at a point.
-    pub fn with_z_order(point: P, sprite_index: usize, z_order: usize) -> Tile<P, Color> {
+    pub fn with_z_order<P: Into<Point2>>(point: P, sprite_index: usize, z_order: usize) -> Tile {
         Tile {
-            point,
+            point: point.into(),
             z_order,
             sprite_index,
             tint: Color::WHITE,
         }
     }
-}
 
-impl<P: Into<Point2>, C: Into<Color>> Tile<P, C> {
     /// Creates a new tile with a color and a given sprite index.
     ///
     /// The color argument implements `Into<[`Color`]>`.
@@ -121,12 +119,16 @@ impl<P: Into<Point2>, C: Into<Color>> Tile<P, C> {
     /// ```
     ///
     /// [`Color`]: Bevy::render::color::Color
-    pub fn with_tint(point: P, sprite_index: usize, tint: C) -> Tile<P, C> {
+    pub fn with_tint<P: Into<Point2>, C: Into<Color>>(
+        point: P,
+        sprite_index: usize,
+        tint: C,
+    ) -> Tile {
         Tile {
-            point,
+            point: point.into(),
             z_order: 0,
             sprite_index,
-            tint,
+            tint: tint.into(),
         }
     }
 
@@ -146,17 +148,17 @@ impl<P: Into<Point2>, C: Into<Color>> Tile<P, C> {
     ///
     /// let tile = Tile::with_z_order_and_tint(point, z_order, sprite_index, tint);
     /// ```
-    pub fn with_z_order_and_tint(
+    pub fn with_z_order_and_tint<P: Into<Point2>, C: Into<Color>>(
         point: P,
         sprite_index: usize,
         z_order: usize,
         tint: C,
-    ) -> Tile<P, C> {
+    ) -> Tile {
         Tile {
-            point,
+            point: point.into(),
             z_order,
             sprite_index,
-            tint,
+            tint: tint.into(),
         }
     }
 }

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -1158,7 +1158,7 @@ impl Tilemap {
 
         let mut chunk_map: HashMap<Point2, Vec<Tile>> = HashMap::default();
         for tile in tiles.into_iter() {
-            let global_tile_point: Point2 = tile.point.into();
+            let global_tile_point: Point2 = tile.point;
             let chunk_point: Point2 = self.tile_to_chunk_point(global_tile_point).into();
 
             if let Some(layer) = self.layers.get(tile.z_order as usize) {
@@ -1178,7 +1178,7 @@ impl Tilemap {
                 point: tile_point,
                 z_order: tile.z_order,
                 sprite_index: tile.sprite_index,
-                tint: tile.tint.into(),
+                tint: tile.tint,
             };
             if let Some(tiles) = chunk_map.get_mut(&chunk_point) {
                 tiles.push(chunk_tile);

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -198,7 +198,7 @@ pub(crate) enum TilemapEvent {
         /// The map index where the chunk needs to be stored.
         handle: Handle<Chunk>,
         /// The tiles that need to be set.
-        tiles: Vec<Tile<Point2, Color>>,
+        tiles: Vec<Tile>,
     },
     /// An event when a chunk is spawned.
     SpawnedChunk {
@@ -1149,16 +1149,14 @@ impl Tilemap {
     /// ```
     ///
     /// [`insert_tile`]: Tilemap::insert_tile
-    pub fn insert_tiles<P, C, I>(&mut self, tiles: I) -> TilemapResult<()>
+    pub fn insert_tiles<I>(&mut self, tiles: I) -> TilemapResult<()>
     where
-        P: Into<Point2>,
-        C: Into<Color>,
-        I: IntoIterator<Item = Tile<P, C>>,
+        I: IntoIterator<Item = Tile>,
     {
         let width = self.chunk_dimensions.width as i32;
         let height = self.chunk_dimensions.height as i32;
 
-        let mut chunk_map: HashMap<Point2, Vec<Tile<Point2, Color>>> = HashMap::default();
+        let mut chunk_map: HashMap<Point2, Vec<Tile>> = HashMap::default();
         for tile in tiles.into_iter() {
             let global_tile_point: Point2 = tile.point.into();
             let chunk_point: Point2 = self.tile_to_chunk_point(global_tile_point).into();
@@ -1176,7 +1174,7 @@ impl Tilemap {
                 global_tile_point.y - (height * chunk_point.y) + (width / 2),
             );
 
-            let chunk_tile: Tile<Point2, Color> = Tile {
+            let chunk_tile: Tile = Tile {
                 point: tile_point,
                 z_order: tile.z_order,
                 sprite_index: tile.sprite_index,
@@ -1243,11 +1241,7 @@ impl Tilemap {
     /// ```
     ///
     /// [`insert_tiles`]: Tilemap::insert_tiles
-    pub fn insert_tile<P, C>(&mut self, tile: Tile<P, C>) -> TilemapResult<()>
-    where
-        P: Into<Point2>,
-        C: Into<Color>,
-    {
+    pub fn insert_tile(&mut self, tile: Tile) -> TilemapResult<()> {
         let tiles = vec![tile];
         self.insert_tiles(tiles)
     }


### PR DESCRIPTION
It was pointless to have Tile generics so these were removed. All API should be the same if people chose to use it.