### PR TITLE
Fix rustc lint check with Github actions

### DIFF
--- a/crates/sprite_sheet/src/lib.rs
+++ b/crates/sprite_sheet/src/lib.rs
@@ -5,7 +5,6 @@
 #![no_implicit_prelude]
 // rustc
 #![warn(
-    missing_crate_level_docs,
     missing_doc_code_examples,
     missing_docs,
     private_doc_tests

--- a/crates/sprite_sheet/src/lib.rs
+++ b/crates/sprite_sheet/src/lib.rs
@@ -4,11 +4,7 @@
 
 #![no_implicit_prelude]
 // rustc
-#![warn(
-    missing_doc_code_examples,
-    missing_docs,
-    private_doc_tests
-)]
+#![warn(missing_doc_code_examples, missing_docs, private_doc_tests)]
 #![deny(dead_code, unused_imports)]
 // clippy
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -6,7 +6,6 @@
 #![no_implicit_prelude]
 // rustc / rustdoc
 #![warn(
-    missing_crate_level_docs,
     missing_doc_code_examples,
     missing_docs,
     private_doc_tests

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -5,11 +5,7 @@
 
 #![no_implicit_prelude]
 // rustc / rustdoc
-#![warn(
-    missing_doc_code_examples,
-    missing_docs,
-    private_doc_tests
-)]
+#![warn(missing_doc_code_examples, missing_docs, private_doc_tests)]
 #![deny(dead_code, unused_imports)]
 // clippy
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,6 @@
 #![no_implicit_prelude]
 // rustc
 #![warn(
-    missing_crate_level_docs,
     missing_doc_code_examples,
     missing_docs,
     private_doc_tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,11 +57,7 @@
 
 #![no_implicit_prelude]
 // rustc
-#![warn(
-    missing_doc_code_examples,
-    missing_docs,
-    private_doc_tests
-)]
+#![warn(missing_doc_code_examples, missing_docs, private_doc_tests)]
 #![deny(dead_code, unused_imports)]
 // clippy
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]


### PR DESCRIPTION
`missing_crate_level_docs` rustc check is a compiler check and only available on Nightly. This causes issues when we are checking rustc checks on other Rust releases.