### PR TITLE
auto_chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 * Auto configuration of optimal chunk sizes to texture size as well as checks
-to ensure that the tiles are divisible into each other had been added.
+to ensure that the tiles are divisible into each other had been added. This can
+be enabled in the `TilemapBuilder` with `toggle_auto_configure`.
+* Auto chunk which will create new chunks automatically if you push a tile into
+it. This can be enabled in the `TilemapBuilder` with `toggle_auto_chunk`
 * Optional dimension 2D and 3D API.
 * `TilemapDefaultPlugins` was added.
 * `SpriteSheet` was added which is very much like `TextureAtlas` but it splits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * Auto configuration of optimal chunk sizes to texture size as well as checks
 to ensure that the tiles are divisible into each other had been added. This can
-be enabled in the `TilemapBuilder` with `toggle_auto_configure`.
+be enabled in the `TilemapBuilder` with `auto_configure`.
 * Auto chunk which will create new chunks automatically if you push a tile into
-it. This can be enabled in the `TilemapBuilder` with `toggle_auto_chunk`
+it. This can be enabled in the `TilemapBuilder` with `auto_chunk`
 * Optional dimension 2D and 3D API.
 * `TilemapDefaultPlugins` was added.
 * `SpriteSheet` was added which is very much like `TextureAtlas` but it splits
@@ -33,6 +33,8 @@ still accessible as normal and optional.
 * `Tile` had all generics removed from it.
 * `Tilemap::new_chunk` is now `Tilemap::insert_chunk` to reflect the storage
 internally.
+* It is now required to specify if chunks are to be auto created in the 
+`TilemapBuilder` with `auto_chunk` method.
 
 ## [0.2.2] - 2020-11-23
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ rand = "0.7"
 [[example]]
 name = "random_dungeon"
 path = "examples/random_dungeon.rs"
+
+[[example]]
+name = "stress_dwarves"
+path = "examples/stress_dwarves.rs"

--- a/examples/random_dungeon.rs
+++ b/examples/random_dungeon.rs
@@ -119,6 +119,12 @@ fn build_random_dungeon(
     }
 
     for mut map in query.iter_mut() {
+        // Since we did not `toggle_auto_tile` in the builder, we must manually
+        // insert a chunk. This will then communicate with us if we accidentally
+        // insert a tile in a chunk we may not want. Also, we only expect to 
+        // have just 1 chunk.
+        map.insert_chunk((0, 0)).unwrap();
+
         let chunk_width = (map.width().unwrap() * map.chunk_width()) as i32;
         let chunk_height = (map.height().unwrap() * map.chunk_height()) as i32;
 

--- a/examples/random_dungeon.rs
+++ b/examples/random_dungeon.rs
@@ -121,7 +121,7 @@ fn build_random_dungeon(
     for mut map in query.iter_mut() {
         // Since we did not `toggle_auto_tile` in the builder, we must manually
         // insert a chunk. This will then communicate with us if we accidentally
-        // insert a tile in a chunk we may not want. Also, we only expect to 
+        // insert a tile in a chunk we may not want. Also, we only expect to
         // have just 1 chunk.
         map.insert_chunk((0, 0)).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,8 @@ mod lib {
         point::Point2,
     };
 
+    pub use crate::bitflags::*;
+
     #[cfg(feature = "serde")]
     pub use serde::{Deserialize, Serialize};
 

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -185,6 +185,7 @@ enum ChunkEvent {
 }
 
 bitflags! {
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     struct AutoFlags: u16 {
         const NONE = 0b0;
         const AUTO_CONFIGURE = 0b0000_0000_0000_0001;

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -132,7 +132,7 @@ impl Display for ErrorKind {
                 f,
                 "texture atlas is missing, must use `TilemapBuilder::texture_atlas`"
             ),
-            MissingChunk => write!(f, "the chunk does not exist, try `add_chunk` first")
+            MissingChunk => write!(f, "the chunk does not exist, try `add_chunk` first"),
         }
     }
 }
@@ -482,19 +482,19 @@ impl TilemapBuilder {
     }
 
     /// Sets if you want the tilemap to automatically spawn new chunks.
-    /// 
-    /// This is useful if the tilemap map is meant to be endless or nearly 
+    ///
+    /// This is useful if the tilemap map is meant to be endless or nearly
     /// endless with a defined size. Otherwise, it probably is better to spawn
-    /// chunks directly or creating a system that can automatically spawn and 
+    /// chunks directly or creating a system that can automatically spawn and
     /// despawn them given context.
-    /// 
+    ///
     /// By default this is not enabled.
-    /// 
+    ///
     /// # Examples
     /// ```
     /// use bevy_tilemap::prelude::*;
     /// use bevy::prelude::*;
-    /// 
+    ///
     /// let builder = TilemapBuilder::new().auto_configure(false);
     /// ```
     pub fn auto_chunk(mut self) -> Self {
@@ -1172,10 +1172,9 @@ impl Tilemap {
             let layers = self.layers.clone();
             let chunk_dimensions = self.chunk_dimensions;
             let chunk = if self.auto_flags.contains(AutoFlags::AUTO_CHUNK) {
-                self
-                .chunks
-                .entry(point)
-                .or_insert_with(|| Chunk::new(point, &layers, chunk_dimensions))
+                self.chunks
+                    .entry(point)
+                    .or_insert_with(|| Chunk::new(point, &layers, chunk_dimensions))
             } else {
                 match self.chunks.get_mut(&point) {
                     Some(c) => c,

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -1115,6 +1115,8 @@ impl Tilemap {
     /// #
     /// # let mut tilemap = Tilemap::new(texture_atlas_handle);
     /// #
+    /// tilemap.insert_chunk((0, 0)).unwrap();
+    ///
     /// let mut tiles = vec![
     ///     Tile::new((1, 1), 0),
     ///     Tile::new((2, 2), 0),
@@ -1226,6 +1228,8 @@ impl Tilemap {
     /// #
     /// # let mut tilemap = Tilemap::new(texture_atlas_handle);
     /// #
+    /// tilemap.insert_chunk((0, 0)).unwrap();
+    ///
     /// let point = (9, 3);
     /// let sprite_index = 3;
     /// let tile = Tile::new(point, sprite_index);
@@ -1253,6 +1257,8 @@ impl Tilemap {
     /// #
     /// # let mut tilemap = Tilemap::new(texture_atlas_handle);
     /// #
+    /// tilemap.insert_chunk((0, 0)).unwrap();
+    ///
     /// let mut tiles = vec![
     ///     Tile::new((1, 1), 0),
     ///     Tile::new((2, 2), 0),
@@ -1308,6 +1314,8 @@ impl Tilemap {
     /// #
     /// # let mut tilemap = Tilemap::new(texture_atlas_handle);
     /// #
+    /// tilemap.insert_chunk((0, 0)).unwrap();
+    ///
     /// let point = (9, 3);
     /// let sprite_index = 3;
     /// let tile = Tile::new(point, sprite_index);

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -475,7 +475,7 @@ impl TilemapBuilder {
     /// use bevy_tilemap::prelude::*;
     /// use bevy::prelude::*;
     ///
-    /// let builder = TilemapBuilder::new().auto_configure(false);
+    /// let builder = TilemapBuilder::new().auto_configure();
     /// ```
     pub fn auto_configure(mut self) -> TilemapBuilder {
         self.auto_flags.toggle(AutoFlags::AUTO_CONFIGURE);
@@ -496,7 +496,7 @@ impl TilemapBuilder {
     /// use bevy_tilemap::prelude::*;
     /// use bevy::prelude::*;
     ///
-    /// let builder = TilemapBuilder::new().auto_configure(false);
+    /// let builder = TilemapBuilder::new().auto_chunk();
     /// ```
     pub fn auto_chunk(mut self) -> Self {
         self.auto_flags.toggle(AutoFlags::AUTO_CHUNK);


### PR DESCRIPTION
By request, Auto Chunk feature was added to optionally choose if they want the tilemap to be creating chunks automatically or not. This addition communicates if someone accidentally places a tile in a chunk they may not want, displaying an error which they can use as a warning and handle appropriately.

### Added

* Auto chunk which will create new chunks automatically if you push a tile into
it. This can be enabled in the `TilemapBuilder` with `toggle_auto_chunk`