### PR TITLE
Simplify mesh and shaders

### DIFF
--- a/examples/random_dungeon.rs
+++ b/examples/random_dungeon.rs
@@ -137,8 +137,10 @@ fn build_random_dungeon(
 
         // Now we fill the entire space with floors.
         let mut tiles = Vec::new();
-        for y in (-chunk_height / 2)..(chunk_height / 2) {
-            for x in (-chunk_width / 2)..(chunk_width / 2) {
+        for y in 0..chunk_height {
+            for x in 0..chunk_width {
+                let y = y - chunk_height / 2;
+                let x = x - chunk_width / 2;
                 // By default tile sets the Z order at 0. Lower means that tile
                 // will render lower than others. 0 is the absolute bottom
                 // level which is perfect for backgrounds.

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -62,11 +62,6 @@ impl Default for ChunkComponents {
                         bind_group: 2,
                         binding: 0,
                     },
-                    // Chunk
-                    DynamicBinding {
-                        bind_group: 2,
-                        binding: 1,
-                    },
                 ],
                 ..Default::default()
             },

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -27,10 +27,10 @@ impl From<&ChunkMesh> for Mesh {
         let mut vertices = Vec::with_capacity((chunk_width * chunk_height) as usize * 4);
         for y in 0..chunk_height {
             for x in 0..chunk_width {
-                let y0 = y as f32 / chunk_height as f32 - 0.5;
-                let y1 = (y + 1) as f32 / chunk_height as f32 - 0.5;
-                let x0 = x as f32 / chunk_width as f32 - 0.5;
-                let x1 = (x + 1) as f32 / chunk_width as f32 - 0.5;
+                let y0 = y as f32 - chunk_height as f32 / 2.0;
+                let y1 = (y + 1) as f32 - chunk_height as f32 / 2.0;
+                let x0 = x as f32 - chunk_width as f32 / 2.0;
+                let x1 = (x + 1) as f32 - chunk_width as f32 / 2.0;
 
                 vertices.push([x0, y0, 0.0]);
                 vertices.push([x0, y1, 0.0]);

--- a/src/render/tilemap.vert
+++ b/src/render/tilemap.vert
@@ -31,15 +31,11 @@ layout(set = 2, binding = 0) uniform Transform {
     mat4 ChunkTransform;
 };
 
-layout(set = 2, binding = 1) uniform ChunkDimensions {
-    vec3 Dimensions;
-};
-
 void main() {
     Rect sprite_rect = Textures[int(Vertex_Tile_Index)];
     vec2 sprite_dimensions = sprite_rect.end - sprite_rect.begin;
     vec3 vertex_position = vec3(
-        Vertex_Position.xy * sprite_dimensions * Dimensions.xy,
+        Vertex_Position.xy * sprite_dimensions,
         0.0
     );
     vec2 atlas_positions[4] = vec2[](


### PR DESCRIPTION
Remove chunk dimensions from shader inputs and set vertex positions
directly in mesh. Prevents rounding / off-by-1-pixel errors.