### PR TITLE
fix floating point error in the square tilemap shader

### DIFF
--- a/src/render/tilemap-hex-x.vert
+++ b/src/render/tilemap-hex-x.vert
@@ -61,7 +61,7 @@ void main() {
         vec2(sprite_rect.end.x, sprite_rect.begin.y),
         sprite_rect.end
     );
-    v_Uv = (atlas_positions[local_index]) / AtlasSize;
+    v_Uv = floor(atlas_positions[local_index]) / AtlasSize;
     v_Color = Vertex_Tile_Color;
     gl_Position = ViewProj * ChunkTransform * vec4(ceil(vertex_position), 1.0);
 }

--- a/src/render/tilemap-hex-y.vert
+++ b/src/render/tilemap-hex-y.vert
@@ -61,7 +61,7 @@ void main() {
         vec2(sprite_rect.end.x, sprite_rect.begin.y),
         sprite_rect.end
     );
-    v_Uv = (atlas_positions[local_index]) / AtlasSize;
+    v_Uv = floor(atlas_positions[local_index]) / AtlasSize;
     v_Color = Vertex_Tile_Color;
     gl_Position = ViewProj * ChunkTransform * vec4(ceil(vertex_position), 1.0);
 }

--- a/src/render/tilemap-hexcols-even.vert
+++ b/src/render/tilemap-hexcols-even.vert
@@ -65,7 +65,7 @@ void main() {
         vec2(sprite_rect.end.x, sprite_rect.begin.y),
         sprite_rect.end
     );
-    v_Uv = (atlas_positions[local_index]) / AtlasSize;
+    v_Uv = floor(atlas_positions[local_index]) / AtlasSize;
     v_Color = Vertex_Tile_Color;
     gl_Position = ViewProj * ChunkTransform * vec4(ceil(vertex_position), 1.0);
 }

--- a/src/render/tilemap-hexcols-odd.vert
+++ b/src/render/tilemap-hexcols-odd.vert
@@ -65,7 +65,7 @@ void main() {
         vec2(sprite_rect.end.x, sprite_rect.begin.y),
         sprite_rect.end
     );
-    v_Uv = (atlas_positions[local_index]) / AtlasSize;
+    v_Uv = floor(atlas_positions[local_index]) / AtlasSize;
     v_Color = Vertex_Tile_Color;
     gl_Position = ViewProj * ChunkTransform * vec4(ceil(vertex_position), 1.0);
 }

--- a/src/render/tilemap-hexrows-even.vert
+++ b/src/render/tilemap-hexrows-even.vert
@@ -65,7 +65,7 @@ void main() {
         vec2(sprite_rect.end.x, sprite_rect.begin.y),
         sprite_rect.end
     );
-    v_Uv = (atlas_positions[local_index]) / AtlasSize;
+    v_Uv = floor(atlas_positions[local_index]) / AtlasSize;
     v_Color = Vertex_Tile_Color;
     gl_Position = ViewProj * ChunkTransform * vec4(ceil(vertex_position), 1.0);
 }

--- a/src/render/tilemap-hexrows-odd.vert
+++ b/src/render/tilemap-hexrows-odd.vert
@@ -65,7 +65,7 @@ void main() {
         vec2(sprite_rect.end.x, sprite_rect.begin.y),
         sprite_rect.end
     );
-    v_Uv = (atlas_positions[local_index]) / AtlasSize;
+    v_Uv = floor(atlas_positions[local_index]) / AtlasSize;
     v_Color = Vertex_Tile_Color;
     gl_Position = ViewProj * ChunkTransform * vec4(ceil(vertex_position), 1.0);
 }

--- a/src/render/tilemap-square.vert
+++ b/src/render/tilemap-square.vert
@@ -45,7 +45,7 @@ void main() {
         vec2(sprite_rect.end.x, sprite_rect.begin.y),
         sprite_rect.end
     );
-    v_Uv = (atlas_positions[gl_VertexIndex % 4] + vec2(0.01, 0.01)) / AtlasSize;
+    v_Uv = floor(atlas_positions[gl_VertexIndex % 4] + vec2(0.01, 0.01)) / AtlasSize;
     v_Color = Vertex_Tile_Color;
     gl_Position = ViewProj * ChunkTransform * vec4(ceil(vertex_position), 1.0);
 }


### PR DESCRIPTION
 Floor the UV in the shader so that tile bondaries don't sparkle when the camera moves by fractional pixels.