### PR TITLE
fix wrong offset in hex vertex shader

### DIFF
--- a/src/render/tilemap-hex-x.vert
+++ b/src/render/tilemap-hex-x.vert
@@ -50,10 +50,10 @@ void main() {
 
     // offset cols
     float yoffset = floor(0.5 * sprite_dimensions.y);
-    vertex_position.y += yoffset * (float(col) - 0.5);
+    vertex_position.y += yoffset * float(col);
 
     // compact (remove gaps between cols)
-    vertex_position.x -= (float(col) - 0.5) * ceil(0.25 * sprite_dimensions.x);
+    vertex_position.x -= float(col) * ceil(0.25 * sprite_dimensions.x);
 
     vec2 atlas_positions[4] = vec2[](
         vec2(sprite_rect.begin.x, sprite_rect.end.y),

--- a/src/render/tilemap-hex-y.vert
+++ b/src/render/tilemap-hex-y.vert
@@ -50,10 +50,10 @@ void main() {
 
     // offset rows
     float xoffset = floor(0.5 * sprite_dimensions.x);
-    vertex_position.x += xoffset * (float(row) - 0.5);
+    vertex_position.x += xoffset * float(row);
 
     // compact (remove gaps between rows)
-    vertex_position.y -= (float(row) - 0.5) * ceil(0.25 * sprite_dimensions.y);
+    vertex_position.y -= float(row) * ceil(0.25 * sprite_dimensions.y);
 
     vec2 atlas_positions[4] = vec2[](
         vec2(sprite_rect.begin.x, sprite_rect.end.y),

--- a/src/render/tilemap-hexcols-even.vert
+++ b/src/render/tilemap-hexcols-even.vert
@@ -57,7 +57,7 @@ void main() {
     }
 
     // compact (remove gaps between cols)
-    vertex_position.x -= (float(col) - 0.5) * ceil(0.25 * sprite_dimensions.x);
+    vertex_position.x -= float(col) * ceil(0.25 * sprite_dimensions.x);
 
     vec2 atlas_positions[4] = vec2[](
         vec2(sprite_rect.begin.x, sprite_rect.end.y),

--- a/src/render/tilemap-hexcols-odd.vert
+++ b/src/render/tilemap-hexcols-odd.vert
@@ -57,7 +57,7 @@ void main() {
     }
 
     // compact (remove gaps between cols)
-    vertex_position.x -= (float(col) - 0.5) * ceil(0.25 * sprite_dimensions.x);
+    vertex_position.x -= float(col) * ceil(0.25 * sprite_dimensions.x);
 
     vec2 atlas_positions[4] = vec2[](
         vec2(sprite_rect.begin.x, sprite_rect.end.y),

--- a/src/render/tilemap-hexrows-even.vert
+++ b/src/render/tilemap-hexrows-even.vert
@@ -57,7 +57,7 @@ void main() {
     }
 
     // compact (remove gaps between rows)
-    vertex_position.y -= (float(row) - 0.5) * ceil(0.25 * sprite_dimensions.y);
+    vertex_position.y -= float(row) * ceil(0.25 * sprite_dimensions.y);
 
     vec2 atlas_positions[4] = vec2[](
         vec2(sprite_rect.begin.x, sprite_rect.end.y),

--- a/src/render/tilemap-hexrows-odd.vert
+++ b/src/render/tilemap-hexrows-odd.vert
@@ -57,7 +57,7 @@ void main() {
     }
 
     // compact (remove gaps between rows)
-    vertex_position.y -= (float(row) - 0.5) * ceil(0.25 * sprite_dimensions.y);
+    vertex_position.y -= float(row) * ceil(0.25 * sprite_dimensions.y);
 
     vec2 atlas_positions[4] = vec2[](
         vec2(sprite_rect.begin.x, sprite_rect.end.y),


### PR DESCRIPTION
This `0.5` offset is unnecessary (I guess it "looked nice" in the testing example), it results in bad tile positioning (the middle tile not being centered at the origin).