### PR TITLE
Disable windows build on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ exclude = ["assets/**/*", ".github/**/*", "doc/**/*"]
 
 [package.metadata.docs.rs]
 features = ["serialize", "types"]
-default-target = "x86_64-pc-windows-msvc"
+# This may have broken the doc build. Going to disable it for now.
+# default-target = "x86_64-pc-windows-msvc"
 
 [features]
 serialize = ["bevy_tilemap_types/serialize", "serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ exclude = ["assets/**/*", ".github/**/*", "doc/**/*"]
 
 [package.metadata.docs.rs]
 features = ["serialize", "types"]
-# This may have broken the doc build. Going to disable it for now.
-# default-target = "x86_64-pc-windows-msvc"
 
 [features]
 serialize = ["bevy_tilemap_types/serialize", "serde"]

--- a/library/types/Cargo.toml
+++ b/library/types/Cargo.toml
@@ -11,7 +11,8 @@ documentation = "https://docs.rs/bevy_tilemap/latest/bevy_tilemap_types/"
 
 [package.metadata.docs.rs]
 features = ["serialize"]
-default-target = "x86_64-pc-windows-msvc"
+# This may have broken the doc build. Going to disable it for now.
+# default-target = "x86_64-pc-windows-msvc"
 
 [features]
 serialize = ["serde"]

--- a/library/types/Cargo.toml
+++ b/library/types/Cargo.toml
@@ -11,8 +11,6 @@ documentation = "https://docs.rs/bevy_tilemap/latest/bevy_tilemap_types/"
 
 [package.metadata.docs.rs]
 features = ["serialize"]
-# This may have broken the doc build. Going to disable it for now.
-# default-target = "x86_64-pc-windows-msvc"
 
 [features]
 serialize = ["serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,10 @@
 //!
 //! # Extra types feature
 //!
-//! Internally, the library uses [`Point2`], [`Point3`], [`Dimension2`] and
-//! [`Dimension3`] types. This is not part of the official Bevy library and
-//! multiple or alternative implementations of them may not be ideal, especially
-//! not in the prelude.
+//! Internally, the library uses Point2, Point3, Dimension2 and Dimension3
+//! types. This is not part of the official Bevy library and multiple or
+//! alternative implementations of them may not be ideal, especially not in the
+//! prelude.
 //!
 //! It is quite important however to `impl Into<T>` for each of them for most
 //! public methods. It already has most basic implementations that make sense.
@@ -51,10 +51,7 @@
 //! bevy_tilemap = { version = "0.2", features = ["types"] }
 //! ```
 //!
-//! [`Point2`]: crate::point::Point2
-//! [`Point3`]: crate::point::Point3
-//! [`Dimension2`]: crate::dimension::Dimension2
-//! [`Dimension3`]: crate::dimension::Dimension3
+//! See the library `bevy_tilemap_types` for more information.
 
 #![doc(html_root_url = "https://docs.rs/bevy_tilemap/0.3.0")]
 // This was broken even further and no longer will work at all with the previous

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,27 +18,16 @@
 //! * [`bevy_tilemap`]::[`Tilemap2DPlugin`], the main plugin with
 //! a collection of systems, components and assets to be used in a Bevy app.
 //!
-//! If **"types"** feature is enabled it re-exports the following.
-//!
-//! * [`bevy_tilemap::dimension`]::{[`Dimension2`], [`Dimension3`]}
-//! common methods and helpers for dealing with dimensions.
-//! * [`bevy_tilemap::point`]::{[`Point2`], [`Point3`]} common methods
-//! and helpers for dealing with points of the 2nd and 3rd dimension.
-//!
 //! [`bevy_tilemap::prelude::v0`]: crate::prelude::v0
 //! [`bevy_tilemap::default_plugin`]: crate::default_plugin
 //! [`bevy_tilemap::chunk`]: crate::chunk
 //! [`bevy_tilemap::entity`]: crate::entity
 //! [`bevy_tilemap::tile`]: crate::tile
 //! [`bevy_tilemap::tilemap`]: crate::tilemap
-//! [`bevy_tilemap::dimension`]: crate::dimension
-//! [`bevy_tilemap::point`]: crate::point
 //! [`bevy_tilemap`]: crate
 
 /// Version 0 prelude.
 pub mod v0 {
-    #[cfg(feature = "types")]
-    pub use crate::bevy_tilemap_types::prelude::v0::*;
     pub use crate::{
         chunk::LayerKind,
         default_plugin::TilemapDefaultPlugins,


### PR DESCRIPTION
For whatever reason docs.rs fails to compile spriv-reflect. I have a sneaky suspicion that this is the cause here. If this does not work, then something else may need to be attempted.