### PR TITLE
Misc version bumps

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "bevy_tilemap_examples"
-version = "0.2.2"
+version = "0.1.0"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>"]
 edition = "2018"
 description = "Examples for bevy_tilemap."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bevy_tilemap = { version = "0.2", features = ["serialize"] }
+//! bevy_tilemap = { version = "0.3", features = ["serialize"] }
 //! ```
 //!
 //! # Extra types feature


### PR DESCRIPTION
* Examples should stay on v0.1. No point bumping it.
* Missed a lib.rs version bump.