### PR TITLE
Fix auto_configure tile size spam

### DIFF
--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -1812,6 +1812,7 @@ pub(crate) fn tilemap_auto_configure(
         for size in sizes.into_iter() {
             if size % base_size != 0 {
                 error!(target: "tilemap_events", "the tiles in the set `TextureAtlas` must be divisible by the smallest itle, can not auto configure");
+                map.auto_flags.toggle(AutoFlags::AUTO_CONFIGURE);
                 return;
             }
         }


### PR DESCRIPTION
There is currently a lot of spam in the auto configure if a tile isn't sized correctly. This turns the auto configure flag off after displaying that error.