### PR TITLE
Fix player movement in sprite_dungeon example

### DIFF
--- a/examples/examples/sprite_dungeon.rs
+++ b/examples/examples/sprite_dungeon.rs
@@ -231,7 +231,7 @@ fn build_random_dungeon(
             .with(Player {})
             .with(RigidBodyBuilder::new_dynamic().lock_rotations())
             .with(
-                ColliderBuilder::cuboid(16.0, 16.0).collision_groups(InteractionGroups::new(
+                ColliderBuilder::ball(16.0).collision_groups(InteractionGroups::new(
                     0b0000_0000_0000_0010,
                     0b0000_0000_0000_0001,
                 )),
@@ -257,15 +257,15 @@ fn character_movement(
         return;
     }
 
-    for (mut map, mut timer) in map_query.iter_mut() {
+    for (mut _map, mut _timer) in map_query.iter_mut() {
         for (rbdhc, _player) in player_query.iter_mut() {
             let rbd = rigid_body_set.get_mut(rbdhc.handle()).unwrap();
 
-            let mut move_velocity = Vec2::new(0.0, 0.0);
+            let mut move_velocity = Vector::new(0.0, 0.0);
 
             for key in keyboard_input.get_pressed() {
                 for _camera in camera_query.iter_mut() {
-                    let move_step = 5000.0;
+                    let move_step = 200000.0;
                     // Of course we need to control where we are going to move our
                     // dwarf friend.
                     use KeyCode::*;
@@ -288,7 +288,7 @@ fn character_movement(
                 }
             }
 
-            rbd.apply_impulse(Vector::new(move_velocity.x, move_velocity.y), true);
+            rbd.apply_impulse(move_velocity * time.delta_seconds(), true);
 
             // let mut pos = *rbd.position();
             //

--- a/examples/examples/sprite_dungeon.rs
+++ b/examples/examples/sprite_dungeon.rs
@@ -231,7 +231,7 @@ fn build_random_dungeon(
             .with(Player {})
             .with(RigidBodyBuilder::new_dynamic().lock_rotations())
             .with(
-                ColliderBuilder::ball(16.0).collision_groups(InteractionGroups::new(
+                ColliderBuilder::ball(14.0).collision_groups(InteractionGroups::new(
                     0b0000_0000_0000_0010,
                     0b0000_0000_0000_0001,
                 )),
@@ -265,7 +265,7 @@ fn character_movement(
 
             for key in keyboard_input.get_pressed() {
                 for _camera in camera_query.iter_mut() {
-                    let move_step = 200000.0;
+                    let move_step = 100_000.0;
                     // Of course we need to control where we are going to move our
                     // dwarf friend.
                     use KeyCode::*;
@@ -289,13 +289,6 @@ fn character_movement(
             }
 
             rbd.apply_impulse(move_velocity * time.delta_seconds(), true);
-
-            // let mut pos = *rbd.position();
-            //
-            // pos.translation.vector.x += move_velocity.x;
-            // pos.translation.vector.y += move_velocity.y;
-            //
-            // rbd.set_position(pos, true);
         }
     }
 }
@@ -304,8 +297,8 @@ fn main() {
     App::build()
         .add_resource(WindowDescriptor {
             title: "Physics Dungeon".to_string(),
-            width: 1024.,
-            height: 1024.,
+            width: 512.,
+            height: 512.,
             vsync: false,
             resizable: true,
             mode: WindowMode::Windowed,

--- a/examples/examples/sprite_dungeon.rs
+++ b/examples/examples/sprite_dungeon.rs
@@ -4,17 +4,19 @@ use bevy::{
     prelude::*,
     render::camera::Camera,
     sprite::{TextureAtlas, TextureAtlasBuilder},
-    utils::HashSet,
     window::WindowMode,
 };
-use bevy_rapier2d::{physics::RigidBodyHandleComponent, rapier::dynamics::RigidBodySet};
 pub(crate) use bevy_rapier2d::{
+    physics::RapierPhysicsPlugin,
     rapier::{
         dynamics::RigidBodyBuilder,
         geometry::{ColliderBuilder, InteractionGroups},
     },
     render::RapierRenderPlugin,
-    physics::RapierPhysicsPlugin,
+};
+use bevy_rapier2d::{
+    physics::{RapierConfiguration, RigidBodyHandleComponent},
+    rapier::{dynamics::RigidBodySet, ncollide::math::Vector},
 };
 use bevy_tilemap::prelude::*;
 use rand::Rng;
@@ -58,7 +60,13 @@ struct GameState {
     spawned: bool,
 }
 
-fn setup(mut tile_sprite_handles: ResMut<TileSpriteHandles>, asset_server: Res<AssetServer>) {
+fn setup(
+    mut tile_sprite_handles: ResMut<TileSpriteHandles>,
+    asset_server: Res<AssetServer>,
+    mut configuration: ResMut<RapierConfiguration>,
+) {
+    configuration.gravity = Vector::new(0.0, 0.0);
+
     tile_sprite_handles.handles = asset_server.load_folder("textures").unwrap();
 }
 
@@ -86,17 +94,18 @@ fn load(
         let texture_atlas = texture_atlas_builder.finish(&mut textures).unwrap();
         let atlas_handle = texture_atlases.add(texture_atlas);
 
+        let wall_interactions =
+            InteractionGroups::new(0b0000_0000_0000_0001, 0b0000_0000_0000_0010);
         let background_layer = TilemapLayer {
             kind: LayerKind::Dense,
             ..Default::default()
         };
-        let wall_interactions =
-            InteractionGroups::new(0b0000_0000_0000_0001, 0b0000_0000_0000_0010);
         let wall_layer = TilemapLayer {
             kind: LayerKind::Sparse,
-            // interaction_groups: wall_interactions,
+            interaction_groups: wall_interactions,
             ..Default::default()
         };
+
         // These are fairly advanced configurations just to quickly showcase
         // them.
         let tilemap = Tilemap::builder()
@@ -163,8 +172,8 @@ fn build_random_dungeon(
             let x = x - TILEMAP_WIDTH / 2;
             let tile_a = (x, -TILEMAP_HEIGHT / 2);
             let tile_b = (x, TILEMAP_HEIGHT / 2 - 1);
-            tiles.push(Tile::new(tile_a, wall_idx));
-            tiles.push(Tile::new(tile_b, wall_idx));
+            tiles.push(Tile::with_z_order(tile_a, wall_idx, 1));
+            tiles.push(Tile::with_z_order(tile_b, wall_idx, 1));
         }
 
         // Then the wall tiles on the Y axis.
@@ -172,8 +181,8 @@ fn build_random_dungeon(
             let y = y - TILEMAP_HEIGHT / 2;
             let tile_a = (-TILEMAP_WIDTH / 2, y);
             let tile_b = (TILEMAP_WIDTH / 2 - 1, y);
-            tiles.push(Tile::new(tile_a, wall_idx));
-            tiles.push(Tile::new(tile_b, wall_idx));
+            tiles.push(Tile::with_z_order(tile_a, wall_idx, 1));
+            tiles.push(Tile::with_z_order(tile_b, wall_idx, 1));
         }
 
         // Lets just generate some random walls to sparsely place around the dungeon!
@@ -184,7 +193,7 @@ fn build_random_dungeon(
             let y = rng.gen_range((-TILEMAP_HEIGHT / 2)..(TILEMAP_HEIGHT / 2));
             let coord = (x, y, 0i32);
             if coord != (0, 0, 0) {
-                tiles.push(Tile::new((x, y), wall_idx));
+                tiles.push(Tile::with_z_order((x, y), wall_idx, 1));
             }
         }
 
@@ -198,11 +207,16 @@ fn build_random_dungeon(
         // automatically.
         // map.add_layer_with_kind(LayerKind::Sparse, 1).unwrap();
 
-        // // Now lets add in a dwarf friend!
+        // Now lets add in a dwarf friend!
         let dwarf_sprite: Handle<Texture> = asset_server.get_handle("textures/square-dwarf.png");
         let dwarf_sprite_index = texture_atlas.get_texture_index(&dwarf_sprite).unwrap();
-        commands
-            .spawn(SpriteSheetBundle {
+
+        const RAPIER_DEBUG_DRAW: bool = false;
+
+        if RAPIER_DEBUG_DRAW {
+            commands.spawn(());
+        } else {
+            commands.spawn(SpriteSheetBundle {
                 texture_atlas: map.texture_atlas().clone_weak(),
                 sprite: TextureAtlasSprite {
                     index: dwarf_sprite_index as u32,
@@ -210,10 +224,18 @@ fn build_random_dungeon(
                 },
                 transform: Transform::from_translation(Vec3::new(0.0, 0.0, 3.0)),
                 ..Default::default()
-            })
+            });
+        }
+
+        commands
             .with(Player {})
-            .with(RigidBodyBuilder::new_dynamic().translation(16.0, 16.0))
-            .with(ColliderBuilder::cuboid(32.0, 32.0).collision_groups(InteractionGroups::new(0b0000_0000_0000_0010, 0b0000_0000_0001)));
+            .with(RigidBodyBuilder::new_dynamic().lock_rotations())
+            .with(
+                ColliderBuilder::cuboid(16.0, 16.0).collision_groups(InteractionGroups::new(
+                    0b0000_0000_0000_0010,
+                    0b0000_0000_0000_0001,
+                )),
+            );
 
         // Now we pass all the tiles to our map.
         map.insert_tiles(tiles).unwrap();
@@ -223,7 +245,7 @@ fn build_random_dungeon(
 }
 
 fn character_movement(
-    mut game_state: ResMut<GameState>,
+    game_state: Res<GameState>,
     keyboard_input: Res<Input<KeyCode>>,
     time: Res<Time>,
     mut rigid_body_set: ResMut<RigidBodySet>,
@@ -237,14 +259,13 @@ fn character_movement(
 
     for (mut map, mut timer) in map_query.iter_mut() {
         for (rbdhc, _player) in player_query.iter_mut() {
-
             let rbd = rigid_body_set.get_mut(rbdhc.handle()).unwrap();
 
             let mut move_velocity = Vec2::new(0.0, 0.0);
 
             for key in keyboard_input.get_pressed() {
-                for (_camera, mut camera_transform) in camera_query.iter_mut() {
-                    let move_step = 0.5;
+                for _camera in camera_query.iter_mut() {
+                    let move_step = 5000.0;
                     // Of course we need to control where we are going to move our
                     // dwarf friend.
                     use KeyCode::*;
@@ -267,12 +288,14 @@ fn character_movement(
                 }
             }
 
-            let mut pos = *rbd.position();
+            rbd.apply_impulse(Vector::new(move_velocity.x, move_velocity.y), true);
 
-            pos.translation.vector.x += move_velocity.x;
-            pos.translation.vector.y += move_velocity.y;
-
-            rbd.set_position(pos, true);
+            // let mut pos = *rbd.position();
+            //
+            // pos.translation.vector.x += move_velocity.x;
+            // pos.translation.vector.y += move_velocity.y;
+            //
+            // rbd.set_position(pos, true);
         }
     }
 }
@@ -298,5 +321,6 @@ fn main() {
         .add_system(load.system())
         .add_system(build_random_dungeon.system())
         .add_system(character_movement.system())
+        .add_system(bevy::input::system::exit_on_esc_system.system())
         .run()
 }

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -2064,6 +2064,9 @@ pub(crate) fn tilemap(
                         render_pipelines: RenderPipelines::from_pipelines(vec![pipeline]),
                         draw: Default::default(),
                         visible: Visible {
+                            // TODO: this would be nice as a config parameter to make
+                            // RapierRenderPlugin's output visible.
+                            is_visible: true,
                             is_transparent: true,
                             ..Default::default()
                         },
@@ -2117,26 +2120,35 @@ pub(crate) fn tilemap(
                             layer_opt.and_then(|layer| Some(layer.interaction_groups))
                         });
 
-                        let mut collider = ColliderBuilder::cuboid(
-                            tile_dimensions.width as f32,
-                            tile_dimensions.height as f32,
-                        );
-
                         if let Some(collision_groups) = collision_groups {
-                            collider = collider.collision_groups(collision_groups);
-                        }
+                            if collision_groups.with_mask(0).0 != 0 {
+                                let mut collider = ColliderBuilder::cuboid(
+                                    tile_dimensions.width as f32 / 2.0,
+                                    tile_dimensions.height as f32 / 2.0,
+                                );
 
-                        let entity = if let Some(entity) = commands
-                            .spawn((RigidBodyBuilder::new_static().translation(x, y), collider))
-                            .current_entity()
-                        {
-                            entity
-                        } else {
-                            error!("Collider entity does not exist unexpectedly, can not run the tilemap system");
-                            return;
-                        };
-                        debug!("push collider");
-                        collision_entities.push(entity);
+                                collider = collider.collision_groups(collision_groups);
+
+                                let entity = if let Some(entity) = commands
+                                    .spawn((
+                                        RigidBodyBuilder::new_static().translation(
+                                            x * tile_dimensions.width as f32,
+                                            y * tile_dimensions.height as f32,
+                                        ),
+                                        collider,
+                                    ))
+                                    .current_entity()
+                                {
+                                    entity
+                                } else {
+                                    error!("Collider entity does not exist unexpectedly, can not run the tilemap system");
+                                    return;
+                                };
+
+                                debug!("push collider at {} {}", x, y);
+                                collision_entities.push(entity);
+                            }
+                        }
                     }
                 }
                 commands.push_children(entity, &collision_entities);

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -2131,8 +2131,10 @@ pub(crate) fn tilemap(
                                 let entity = if let Some(entity) = commands
                                     .spawn((
                                         RigidBodyBuilder::new_static().translation(
-                                            x * tile_dimensions.width as f32 + (tile_dimensions.width as f32 / 2.0),
-                                            y * tile_dimensions.height as f32 + (tile_dimensions.height as f32 / 2.0),
+                                            x * tile_dimensions.width as f32
+                                                + (tile_dimensions.width as f32 / 2.0),
+                                            y * tile_dimensions.height as f32
+                                                + (tile_dimensions.height as f32 / 2.0),
                                         ),
                                         collider,
                                     ))

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -2116,17 +2116,18 @@ pub(crate) fn tilemap(
                         let collision_groups = layers.get(z_order).and_then(|layer_opt| {
                             layer_opt.and_then(|layer| Some(layer.interaction_groups))
                         });
+
                         let mut collider = ColliderBuilder::cuboid(
                             tile_dimensions.width as f32,
                             tile_dimensions.height as f32,
-                        )
-                        .translation(x, y);
+                        );
+
                         if let Some(collision_groups) = collision_groups {
                             collider = collider.collision_groups(collision_groups);
                         }
 
                         let entity = if let Some(entity) = commands
-                            .spawn((RigidBodyBuilder::new_static(), collider))
+                            .spawn((RigidBodyBuilder::new_static().translation(x, y), collider))
                             .current_entity()
                         {
                             entity

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -2119,7 +2119,6 @@ pub(crate) fn tilemap(
                         let collision_groups = layers.get(z_order).and_then(|layer_opt| {
                             layer_opt.and_then(|layer| Some(layer.interaction_groups))
                         });
-
                         if let Some(collision_groups) = collision_groups {
                             if collision_groups.with_mask(0).0 != 0 {
                                 let mut collider = ColliderBuilder::cuboid(
@@ -2132,8 +2131,8 @@ pub(crate) fn tilemap(
                                 let entity = if let Some(entity) = commands
                                     .spawn((
                                         RigidBodyBuilder::new_static().translation(
-                                            x * tile_dimensions.width as f32,
-                                            y * tile_dimensions.height as f32,
+                                            x * tile_dimensions.width as f32 + (tile_dimensions.width as f32 / 2.0),
+                                            y * tile_dimensions.height as f32 + (tile_dimensions.height as f32 / 2.0),
                                         ),
                                         collider,
                                     ))
@@ -2144,8 +2143,6 @@ pub(crate) fn tilemap(
                                     error!("Collider entity does not exist unexpectedly, can not run the tilemap system");
                                     return;
                                 };
-
-                                debug!("push collider at {} {}", x, y);
                                 collision_entities.push(entity);
                             }
                         }


### PR DESCRIPTION
It's definitely not ideal since you probably don't want to move a `dynamic` rigidbody by setting its transform, but at least it makes the movement work.