### PR TITLE
Drop minor version on crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,19 +31,19 @@ types = []
 members = ["library/*", "examples"]
 
 [dependencies]
-bevy_app = "0.4.0"
-bevy_asset = "0.4.0"
-bevy_core = "0.4.0"
-bevy_ecs = "0.4.0"
-bevy_log = "0.4.0"
-bevy_math = "0.4.0"
-bevy_render = "0.4.0"
-bevy_reflect = "0.4.0"
-bevy_sprite = "0.4.0"
+bevy_app = "0.4"
+bevy_asset = "0.4"
+bevy_core = "0.4"
+bevy_ecs = "0.4"
+bevy_log = "0.4"
+bevy_math = "0.4"
+bevy_render = "0.4"
+bevy_reflect = "0.4"
+bevy_sprite = "0.4"
 bevy_tilemap_types = { path = "library/types", version = "0.1" }
-bevy_transform = "0.4.0"
-bevy_utils = "0.4.0"
-bevy_window = "0.4.0"
-bitflags = "1.2.1"
-hexasphere = "3.1.0"
+bevy_transform = "0.4"
+bevy_utils = "0.4"
+bevy_window = "0.4"
+bitflags = "1.2"
+hexasphere = "3.1"
 serde = { version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
To ensure upmost compatibility with Bevy and other dependencies as well as libraries using this library without continual work on bumping min. versions, the minor version has been dropped in Cargo.toml.

Hopefully, nobody will break API on a minor patch update!