### PR TITLE
Re-export tilemap.rs pub to lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,8 @@ pub mod tile;
 #[no_implicit_prelude]
 pub mod tilemap;
 
-use crate::{lib::*, render::TilemapRenderGraphBuilder, tilemap::Tilemap};
+pub use crate::tilemap::{ChunkEvent, Tilemap, TilemapLayer};
+use crate::{lib::*, render::TilemapRenderGraphBuilder};
 
 /// The Bevy Tilemap 2D main plugin.
 #[derive(Default)]

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -178,7 +178,7 @@ impl From<DimensionError> for TilemapError {
 pub type TilemapResult<T> = Result<T, TilemapError>;
 #[derive(Debug)]
 /// Events that can happen to chunks.
-enum ChunkEvent {
+pub enum ChunkEvent {
     /// An event when a chunk needs to be spawned.
     Spawned {
         /// The point to get the correct chunk to spawn.


### PR DESCRIPTION
This is what all the cool kids are doing these days, plus its related to lib level directory.