### PR TITLE
CI macos-11.0 -> macos.10.15 fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         os:
           - ubuntu-20.04
           - windows-2019
-          - macos-11.0
+          - macos-10.15
         toolchain:
           - stable
           - beta


### PR DESCRIPTION
It appears that the macos-11.0 preview has been made now only available for organisation level and those that are already using it for now.

See: https://github.com/actions/virtual-environments/issues/2486