### PR TITLE
Fixed deprecated use of add_layer_with_kind

### DIFF
--- a/examples/examples/random_dungeon.rs
+++ b/examples/examples/random_dungeon.rs
@@ -222,7 +222,14 @@ fn build_random_dungeon(
         // yet it still works and exists. By default if a layer doesn't exist
         // and tiles need to be written there then a Dense layer is created
         // automatically.
-        map.add_layer_with_kind(LayerKind::Sparse, 1).unwrap();
+        map.add_layer(
+            TilemapLayer {
+                kind: LayerKind::Sparse,
+                ..Default::default()
+            },
+            1,
+        )
+        .unwrap();
 
         // Now lets add in a dwarf friend!
         let dwarf_sprite: Handle<Texture> = asset_server.get_handle("textures/square-dwarf.png");


### PR DESCRIPTION
Running the random_dungeon example on Win10 was causing a `thread 'main' panicked at 'called 'Result::unwrap()' on an 'Err' value: NoSuchEntity'` in `bevy_transform-0.4.0\src\hierarchy\child_builder.rs:65:22`. Looks like it might have been related to inserting a parent which either doesn't exist or with children who don't exist (didn't really look into it so this is just a blind guess). I noticed that random_dungeon was using [add_layer_with_kind](https://github.com/joshuajbouw/bevy_tilemap/blob/207cbdf0294abe2920c59c1ca83bd78c6117f61e/examples/examples/random_dungeon.rs#L225) which is deprecated so I switched to `add_layer` and that seemed to fix the issue.