### PR TITLE
Fix respawn panic and collision tiles offset

### DIFF
--- a/src/chunk/mod.rs
+++ b/src/chunk/mod.rs
@@ -257,15 +257,19 @@ impl Chunk {
         self.collision_entities.get(&index).cloned()
     }
 
-    /// Gets all the layers entities for use with bulk despawning.
-    pub(crate) fn get_entities(&self) -> Vec<Entity> {
+    /// Remove all the layers and collision entities and return them for use with bulk despawning.
+    pub(crate) fn remove_entities(&mut self) -> Vec<Entity> {
         let mut entities = Vec::new();
-        for sprite_layer in &self.sprite_layers {
+        for sprite_layer in &mut self.sprite_layers {
             if let Some(layer) = sprite_layer {
-                if let Some(entity) = layer.entity {
+                if let Some(entity) = layer.entity.take() {
                     entities.push(entity);
                 }
             }
+        }
+        #[cfg(feature = "bevy_rapier2d")]
+        for (_, entity) in self.collision_entities.drain() {
+            entities.push(entity)
         }
         entities
     }

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -1154,7 +1154,7 @@ impl Tilemap {
         self.spawned.remove(&(point.x, point.y));
 
         if let Some(chunk) = self.chunks.get_mut(&point) {
-            let entities = chunk.get_entities();
+            let entities = chunk.remove_entities();
             self.chunk_events
                 .send(TilemapChunkEvent::Despawned { entities, point })
         }


### PR DESCRIPTION
When using multiple chunks with collisions, the chunk offset was added twice for the collision tiles: 
- when the tile was created in the rigidbody translation
- by bevy because the tile was parented to the chunk

In addition, parenting the tile to the chunk sometimes caused a "NoSuchEntity" error. (see #123)

This PR makes the collision tiles parented to the whole tilemap instead.
The collision tiles are thus no longer removed automatically by despawn_recursive, and must be manually despawned.
The "get_entities" method from the chunks was changed to "remove_entities" and now remove all the entities from the chunk (including the collision tiles) and returns them. 
In despawn_chunk, all these entities are despawned.

In addition, the chunk offset added to the rigidbody translation seemed wrong (it was multiplied by both the tile size and the physics tile size. I removed the former).

Finally, I also removed the tilemap position offset for the collision tiles, as the offset is already handled by the parenting.