### PR TITLE
Replace deprecated `ncollide` with `ncollide2d`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,4 +20,5 @@ publish = false
 bevy = "0.4"
 bevy_rapier2d = "0.8.0"
 bevy_tilemap = { path = "../", features = ["bevy_rapier2d", "default"] }
+ncollide2d = "0.27.0"
 rand = "0.8"

--- a/examples/examples/physics_dungeon.rs
+++ b/examples/examples/physics_dungeon.rs
@@ -16,9 +16,10 @@ pub(crate) use bevy_rapier2d::{
 };
 use bevy_rapier2d::{
     physics::{RapierConfiguration, RigidBodyHandleComponent},
-    rapier::{dynamics::RigidBodySet, ncollide::math::Vector},
+    rapier::dynamics::RigidBodySet,
 };
 use bevy_tilemap::prelude::*;
+use ncollide2d::math::Vector;
 use rand::Rng;
 
 const CHUNK_WIDTH: u32 = 16;


### PR DESCRIPTION
ncollide is deprecated and no longer part of rapier
This PR fixes the crash when you try to run physics_dungeon example