### PR TITLE
chore: wrong bevy v in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Less time fiddling, more time building
 Add to your `Cargo.toml` file:
 ```toml
 [dependencies]
-bevy = "0.3"
+bevy = "0.4"
 bevy_tilemap = "0.3"
 ```
 


### PR DESCRIPTION
Version is wrong in the README.md for bevy