### PR TITLE
chore: rustfmt deprecated merge_imports

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-merge_imports = true
+imports_granularity = "Crate"
 use_field_init_shorthand = true
 reorder_imports = true
 reorder_modules = true


### PR DESCRIPTION
`merge_imports` was deprecated by rustfmt in nightly.