### PR TITLE
feat: clear_layer

### DIFF
--- a/src/chunk/layer.rs
+++ b/src/chunk/layer.rs
@@ -17,6 +17,9 @@ pub(super) trait Layer: 'static {
     /// Gets all the tile indices in the layer that exist.
     fn get_tile_indices(&self) -> Vec<usize>;
 
+    /// Clears a layer of all sprites.
+    fn clear(&mut self);
+
     /// Takes all the tiles in the layer and returns attributes for the renderer.
     fn tiles_to_attributes(&self, dimension: Dimension3) -> (Vec<f32>, Vec<[f32; 4]>);
 }
@@ -87,6 +90,10 @@ impl Layer for DenseLayer {
         indices
     }
 
+    fn clear(&mut self) {
+        self.tiles.clear();
+    }
+
     fn tiles_to_attributes(&self, _dimension: Dimension3) -> (Vec<f32>, Vec<[f32; 4]>) {
         crate::chunk::raw_tile::dense_tiles_to_attributes(&self.tiles)
     }
@@ -136,6 +143,10 @@ impl Layer for SparseLayer {
             indices.push(*index);
         }
         indices
+    }
+
+    fn clear(&mut self) {
+        self.tiles.clear();
     }
 
     fn tiles_to_attributes(&self, dimension: Dimension3) -> (Vec<f32>, Vec<[f32; 4]>) {

--- a/src/chunk/mod.rs
+++ b/src/chunk/mod.rs
@@ -306,9 +306,9 @@ impl Chunk {
     /// Clears a given layer of all sprites.
     pub(crate) fn clear_layer(&mut self, layer: usize) {
         if let Some(sprite_layer) = self.z_layers.get_mut(layer) {
-           for layer in sprite_layer.iter_mut().flatten() {
+            for layer in sprite_layer.iter_mut().flatten() {
                 layer.inner.as_mut().clear();
-           }
+            }
         }
     }
 

--- a/src/chunk/mod.rs
+++ b/src/chunk/mod.rs
@@ -303,6 +303,15 @@ impl Chunk {
         })
     }
 
+    /// Clears a given layer of all sprites.
+    pub(crate) fn clear_layer(&mut self, layer: usize) {
+        if let Some(sprite_layer) = self.z_layers.get_mut(layer) {
+           for layer in sprite_layer.iter_mut().flatten() {
+                layer.inner.as_mut().clear();
+           }
+        }
+    }
+
     /// At the given z layer, changes the tiles into attributes for use with
     /// the renderer using the given dimensions.
     ///

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -1703,6 +1703,50 @@ impl Tilemap {
         chunk.get_tile_mut(index, sprite_order, point.z as usize)
     }
 
+    /// Clears a layer of all the tiles.
+    ///
+    /// # Examples
+    /// ```
+    /// use bevy_asset::{prelude::*, HandleId};
+    /// use bevy_render::prelude::*;
+    /// use bevy_sprite::prelude::*;
+    /// use bevy_tilemap::{prelude::*, chunk::RawTile};
+    ///
+    /// // In production use a strong handle from an actual source.
+    /// let texture_atlas_handle = Handle::weak(HandleId::random::<TextureAtlas>());
+    ///
+    /// let mut tilemap = TilemapBuilder::new()
+    ///     .texture_atlas(texture_atlas_handle)
+    ///     .dimensions(1, 1)
+    ///     .texture_dimensions(32, 32)
+    ///     .add_layer( TilemapLayer { kind: LayerKind::Dense}, 0)
+    ///     .add_layer( TilemapLayer { kind: LayerKind::Sparse}, 1)
+    ///     .finish()
+    ///     .unwrap();
+    ///
+    /// assert!(tilemap.clear_layer(0).is_ok());
+    /// assert!(tilemap.clear_layer(1).is_ok());
+    /// assert!(tilemap.clear_layer(2).is_err());
+    /// ```
+    ///
+    /// # Errors
+    /// Fails if the layer does not exist.
+    pub fn clear_layer(&mut self, layer: usize) -> Result<(), TilemapError> {
+        if let Some(l) = self.layers.get(layer) {
+            if l.is_none() {
+                return Err(ErrorKind::LayerDoesNotExist(layer).into());
+            }
+        } else {
+            return Err(ErrorKind::LayerDoesNotExist(layer).into());
+        }
+
+        for chunk in self.chunks.values_mut() {
+            chunk.clear_layer(layer);
+        }
+
+        Ok(())
+    }
+
     /// Returns the center tile, if the tilemap has dimensions.
     ///
     /// Returns `None` if the tilemap has no constrainted dimensions.


### PR DESCRIPTION
Adds the `clear_layer` method to the `Tilemap`. This enables a whole tilemap layer to be cleared.