### PR TITLE
Fixes an issue where a lack of precision causes the GPU to render the tilemap with bad UV's.

### DIFF
--- a/src/chunk/render/tilemap-square.vert
+++ b/src/chunk/render/tilemap-square.vert
@@ -45,7 +45,8 @@ void main() {
         vec2(sprite_rect.end.x, sprite_rect.begin.y),
         sprite_rect.end
     );
-    v_Uv = floor(atlas_positions[gl_VertexIndex % 4] + vec2(0.01, 0.01)) / AtlasSize;
+    v_Uv = floor(atlas_positions[gl_VertexIndex % 4]) / AtlasSize;
+    v_Uv += 1e-5;
     v_Color = Vertex_Tile_Color;
     gl_Position = ViewProj * ChunkTransform * vec4(ceil(vertex_position), 1.0);
 }


### PR DESCRIPTION
Essentially with fractional projection matrices you can see lines like this:
![image](https://user-images.githubusercontent.com/6656977/114736781-66879380-9d14-11eb-8ac3-f8b2ce788f32.png)
with this change we no longer see that issue and instead it looks like this:
![island](https://user-images.githubusercontent.com/6656977/114736902-815a0800-9d14-11eb-9067-99d2e40ee17b.png)
