### PR TITLE
Improve "Simple tilemap example"

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,32 @@ use bevy_tilemap::prelude::*;
 use bevy::asset::HandleId;
 use bevy::prelude::*;
 
-// This must be set in Asset<TextureAtlas>.
+// Build a default Tilemap with 32x32 pixel tiles.
+let mut tilemap = Tilemap::default();
+
+// We need a Asset<TextureAtlas>. For this example we get a random one as a placeholder.
 let texture_atlas_handle = Handle::weak(HandleId::random::<TextureAtlas>());
 
-let mut tilemap = Tilemap::new(texture_atlas_handle, 32, 32);
+// Set the texture atlas for the Tilemap
+tilemap.set_default_texture_atlas(texture_atlas_handle);
 
-// Coordinate point with Z order.
-let point = (16, 16, 0);
-let tile_index = 0;
-tilemap.set_tile(point, tile_index);
+// Create tile data
+let tile = Tile {
+    // 2D location x,y (units are in tiles)
+    point: (16,16),
+    
+    // Which tile from the TextureAtlas
+    sprite_index = 0,
+    
+    // Which z-layer in the Tilemap (0-up)
+    sprite_order = 0,
+    
+    // Give the tile an optional green tint
+    tint: bevy::render::color::Color::GREEN,
+    };
 
-tilemap.spawn_chunk_containing_point(point);
+// Insert a single tile
+tilemap.insert_tile( tile);
 ```
 
 Of course, using the `Tilemap::builder()` this can be constructed with many more


### PR DESCRIPTION
Following the request 1 in joshuajbouw#163, I updated the example to use simpler defaults and the current API.

Changes include:
- Using the default Tilemap to avoid calling `spawn_chunk_at_point` later.
- Explained the use of `HandleId::random::<TextureAtlas>`
- Put the tilemap up top and texture atlas work a little lower.
- Expanded out Tile and explained all the data
- Used `insert_tile` rather than `set_tile`