### PR TITLE
Fix typos in "Improved simple example"

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ let mut tilemap = Tilemap::default();
 let texture_atlas_handle = Handle::weak(HandleId::random::<TextureAtlas>());
 
 // Set the texture atlas for the Tilemap
-tilemap.set_default_texture_atlas(texture_atlas_handle);
+tilemap.set_texture_atlas(texture_atlas_handle);
 
 // Create tile data
 let tile = Tile {
@@ -89,10 +89,10 @@ let tile = Tile {
     point: (16,16),
     
     // Which tile from the TextureAtlas
-    sprite_index = 0,
+    sprite_index: 0,
     
     // Which z-layer in the Tilemap (0-up)
-    sprite_order = 0,
+    sprite_order: 0,
     
     // Give the tile an optional green tint
     tint: bevy::render::color::Color::GREEN,


### PR DESCRIPTION
As per https://github.com/joshuajbouw/bevy_tilemap/pull/167#issuecomment-869399786, fix the typos. I apologise for the errors.